### PR TITLE
Bump versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ First, add the following to your crate's `Cargo.toml`:
 build = "build.rs"
 
 # in section [dependencies]
-askama = "0.1"
-askama_derive = "0.1"
+askama = "0.3"
 
 # in section [build-dependencies]
-askama = "0.1"
+askama = "0.3"
 ```
 
 Because Askama will generate Rust code from your template files,


### PR DESCRIPTION
Without using this version I was getting a warning on stable rust.