### PR TITLE
Fix compilation when deriving from Template and std and askama aren't in scope

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -447,6 +447,9 @@ pub fn generate(ast: &syn::DeriveInput, path: &str, mut nodes: Vec<Node>) -> Str
     }
 
     let mut gen = Generator::new();
+    gen.writeln("use askama;");
+    gen.writeln("use std;");
+
     if !blocks.is_empty() {
         if base.is_none() {
             gen.define_trait(path, &block_names);


### PR DESCRIPTION
I'm not sure if it's the right way to fix it but it fixes it.

Here are the errors i was getting
```
5 | #[derive(Template)]
  |          ^^^^^^^^ Use of undeclared type or module `std`

5 | #[derive(Template)]
  |          ^^^^^^^^ Use of undeclared type or module `askama`
```