### PR TITLE
Adding json and json_pretty filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,8 @@ name = "askama"
 version = "0.3.4"
 dependencies = [
  "askama_derive 0.3.4",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -20,6 +22,16 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -43,9 +55,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "syn"
@@ -71,10 +104,15 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "8a014d9226c2cc402676fbe9ea2e15dd5222cd1dd57f576b5b283178c944a264"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
+"checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
+"checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -17,3 +17,9 @@ travis-ci = { repository = "djc/askama" }
 
 [dependencies]
 askama_derive = { path = "../askama_derive", version = "0.3.4" }
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
+
+[features]
+serde-json = ["serde", "serde_json"]
+default = []

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = { version = "1.0", optional = true }
 [features]
 serde-json = ["serde", "serde_json"]
 default = []
+
+[package.metadata.docs.rs]
+features = [ "serde-json" ]

--- a/askama/src/filters/json.rs
+++ b/askama/src/filters/json.rs
@@ -8,16 +8,6 @@ use serde_json;
 /// This will panic if `S`'s implementation of `Serialize` decides to fail,
 /// or if `T` contains a map with non-string keys.
 pub fn json<S: Serialize>(s: &S) -> String {
-	serde_json::to_string(s).expect("json filter could not serialize input")
-}
-
-/// Serialize to pretty JSON
-///
-/// ## Errors
-///
-/// This will panic if `S`'s implementation of `Serialize` decides to fail,
-/// or if `T` contains a map with non-string keys.
-pub fn json_pretty<S: Serialize>(s: &S) -> String {
 	serde_json::to_string_pretty(s).expect("json filter could not serialize input")
 }
 
@@ -25,15 +15,9 @@ pub fn json_pretty<S: Serialize>(s: &S) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn test_json() {
-        assert_eq!(json(&true), "true");
-        assert_eq!(json(&"foo"), r#""foo""#);
-        assert_eq!(json(&vec!["foo", "bar"]), r#"["foo","bar"]"#);
-    }
 
     #[test]
-    fn test_json_pretty() {
+    fn test_json() {
         assert_eq!(json_pretty(&true), "true");
         assert_eq!(json_pretty(&"foo"), r#""foo""#);
         assert_eq!(json_pretty(&vec!["foo", "bar"]),

--- a/askama/src/filters/json.rs
+++ b/askama/src/filters/json.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use serde_json;
 
-/// Serialize to JSON
+/// Serialize to JSON (requires `serde-json` feature)
 ///
 /// ## Errors
 ///

--- a/askama/src/filters/json.rs
+++ b/askama/src/filters/json.rs
@@ -1,0 +1,45 @@
+use serde::Serialize;
+use serde_json;
+
+/// Serialize to JSON
+///
+/// ## Errors
+///
+/// This will panic if `S`'s implementation of `Serialize` decides to fail,
+/// or if `T` contains a map with non-string keys.
+pub fn json<S: Serialize>(s: &S) -> String {
+	serde_json::to_string(s).expect("json filter could not serialize input")
+}
+
+/// Serialize to pretty JSON
+///
+/// ## Errors
+///
+/// This will panic if `S`'s implementation of `Serialize` decides to fail,
+/// or if `T` contains a map with non-string keys.
+pub fn json_pretty<S: Serialize>(s: &S) -> String {
+	serde_json::to_string_pretty(s).expect("json filter could not serialize input")
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_json() {
+        assert_eq!(json(&true), "true");
+        assert_eq!(json(&"foo"), r#""foo""#);
+        assert_eq!(json(&vec!["foo", "bar"]), r#"["foo","bar"]"#);
+    }
+
+    #[test]
+    fn test_json_pretty() {
+        assert_eq!(json_pretty(&true), "true");
+        assert_eq!(json_pretty(&"foo"), r#""foo""#);
+        assert_eq!(json_pretty(&vec!["foo", "bar"]),
+r#"[
+  "foo",
+  "bar"
+]"#);
+    }
+}

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -7,7 +7,7 @@
 mod json;
 
 #[cfg(feature = "serde-json")]
-pub use self::json::{json, json_pretty};
+pub use self::json::{json};
 
 use std::fmt;
 

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -2,7 +2,15 @@
 //!
 //! Contains all the built-in filter functions for use in templates.
 //! Currently, there is no way to define filters outside this module.
+
+#[cfg(feature = "serde-json")]
+mod json;
+
+#[cfg(feature = "serde-json")]
+pub use self::json::{json, json_pretty};
+
 use std::fmt;
+
 
 fn escapable(b: &u8) -> bool {
     *b == b'<' || *b == b'>' || *b == b'&'

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -214,6 +214,11 @@
 #[macro_use]
 extern crate askama_derive;
 
+#[cfg(feature = "serde-json")]
+extern crate serde;
+#[cfg(feature = "serde-json")]
+extern crate serde_json;
+
 use std::env;
 use std::fs::{self, DirEntry};
 use std::io;

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -6,7 +6,8 @@ workspace = ".."
 build = "build.rs"
 
 [dependencies]
-askama = { path = "../askama", version = "*" }
+serde_json = "1.0"
+askama = { path = "../askama", version = "*", features = ["serde-json"] }
 
 [build-dependencies]
-askama = { path = "../askama", version = "*" }
+askama = { path = "../askama", version = "*", features = ["serde-json"] }

--- a/testing/templates/json.html
+++ b/testing/templates/json.html
@@ -1,1 +1,4 @@
-{"foo": "{{ foo }}", "bar": "{{ bar }}"}
+{
+  "foo": "{{ foo }}",
+  "bar": {{ bar|json }}
+}

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -1,7 +1,10 @@
 #[macro_use]
 extern crate askama;
+#[macro_use]
+extern crate serde_json;
 
 use askama::Template;
+use serde_json::Value;
 
 #[derive(Template)]
 #[template(path = "simple.html")]
@@ -146,11 +149,23 @@ fn test_generics() {
 #[template(path = "json.html")]
 struct JsonTemplate<'a> {
     foo: &'a str,
-    bar: &'a str,
+    bar: &'a Value,
 }
 
 #[test]
 fn test_json() {
-    let t = JsonTemplate { foo: "a", bar: "b" };
-    assert_eq!(t.render(), "{\"foo\": \"a\", \"bar\": \"b\"}");
+    let val =  json!({"arr": [ "one", 2, true, null ]});
+    let t = JsonTemplate { foo: "a", bar: &val };
+    // Note: the json filter lacks a way to specify initial indentation
+    assert_eq!(t.render(), r#"{
+  "foo": "a",
+  "bar": {
+  "arr": [
+    "one",
+    2,
+    true,
+    null
+  ]
+}
+}"#);
 }


### PR DESCRIPTION
You mentioned possibly adding a json filter back in [this comment](https://github.com/djc/askama/issues/24#issuecomment-319890853). At the time, I didn't think I'd need it, but it turns out I did need it (to avoid the temptation to do `"{{my_vec.join("\",\"")}}"` for a simple json list). So I went ahead and hacked together an implementation. I'd be happy to tweak the PR in pretty much any way you want. Some notes:

- [ ] I did move `filters.rs` to `filters/mod.rs`. Wasn't sure how you'd prefer it, but I wanted to minimize usage of `cfg` attributes, and thought this cleaner than a nested `mod json { ... mod tests { ... } }` in `filters.rs`.
- [ ] The tests are kinda dumb - really they are just testing `serde_json`'s functionality. Open to ideas.
- [ ] I hate that it can panic (on serialization errors) currently. Now that you've embraced `render()` returning an error, Askama should probably define it's own error type so that you can return `fmt::Error` or `serde::Error`.
- [ ] Is it valuable to have `json` and `json_pretty` filters? I'm only using the pretty variant.
- [ ] Being feature-flagged behind a non-default feature, the docs for these filters won't appear on docs.rs. So there should probably be some other documentation mentioning the `serde-json` feature.
- [ ] I was surprised to see you check in Cargo.lock for a crate lib. Any particular reason?