### PR TITLE
Don't require for a child template to have every block from its parent

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -10,11 +10,13 @@ use std::collections::{HashMap, HashSet};
 use syn;
 
 pub fn generate(ast: &syn::DeriveInput, path: &Path, mut nodes: Vec<Node>) -> String {
+    let mut parent_src = String::new();
     let mut base: Option<Expr> = None;
     let mut blocks = Vec::new();
     let mut block_names = Vec::new();
     let mut content = Vec::new();
     let mut macros = HashMap::new();
+
     for n in nodes.drain(..) {
         match n {
             Node::Extends(path) => {
@@ -32,6 +34,19 @@ pub fn generate(ast: &syn::DeriveInput, path: &Path, mut nodes: Vec<Node>) -> St
                 macros.insert(name, (ws1, name, params, contents, ws2));
             },
             _ => { content.push(n); },
+        }
+    }
+
+    if let Some(Expr::StrLit(user_path)) = base {
+        let full_path = path::find_template_from_path(&user_path, Some(path));
+        parent_src = path::get_template_source(&full_path);
+        let mut parent_nodes = parser::parse(&parent_src);
+        for n in parent_nodes.drain(..) {
+            if let Node::BlockDef(_, name, ..) = n {
+                if !block_names.contains(&name) {
+                    blocks.push(n);
+                }
+            }
         }
     }
 

--- a/testing/templates/base.html
+++ b/testing/templates/base.html
@@ -1,3 +1,4 @@
 {{ title }}
 {% block content %}{% endblock %}
+{% block foo %}Foo{% endblock %}
 Copyright 2017

--- a/testing/tests/inheritance.rs
+++ b/testing/tests/inheritance.rs
@@ -18,11 +18,11 @@ struct ChildTemplate<'a> {
 #[test]
 fn test_use_base_directly() {
     let t = BaseTemplate { title: "Foo" };
-    assert_eq!(t.render().unwrap(), "Foo\n\nCopyright 2017");
+    assert_eq!(t.render().unwrap(), "Foo\n\nFoo\nCopyright 2017");
 }
 
 #[test]
 fn test_simple_extends() {
     let t = ChildTemplate { _parent: BaseTemplate { title: "Bar" } };
-    assert_eq!(t.render().unwrap(), "Bar\n(Bar) Content goes here\nCopyright 2017");
+    assert_eq!(t.render().unwrap(), "Bar\n(Bar) Content goes here\nFoo\nCopyright 2017");
 }


### PR DESCRIPTION
This allows you to have default blocks in parent templates that can be
ignored in children templates.