### PR TITLE
Content-type inference for Iron support

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -301,6 +301,7 @@ pub mod iron {
     extern crate iron;
     pub use self::iron::modifier::Modifier;
     pub use self::iron::response::Response;
+    pub use self::iron::headers::ContentType;
 }
 
 #[cfg(feature = "with-rocket")]

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -251,6 +251,15 @@ impl<'a> Generator<'a> {
         self.write_header(state, "::askama::iron::Modifier<::askama::iron::Response>", &[]);
         self.writeln("fn modify(self, res: &mut ::askama::iron::Response) {");
         self.writeln("res.body = Some(Box::new(self.render().unwrap().into_bytes()));");
+
+        let ext = state.input.path.extension().map_or("", |s| s.to_str().unwrap_or(""));
+        match ext {
+            "html" | "htm" => {
+                self.writeln("::askama::iron::ContentType::html().0.modify(res);");
+            },
+            _ => (),
+        };
+
         self.writeln("}");
         self.writeln("}");
     }

--- a/testing/templates/hello.txt
+++ b/testing/templates/hello.txt
@@ -1,0 +1,1 @@
+Hello, {{ name }}!

--- a/testing/tests/iron.rs
+++ b/testing/tests/iron.rs
@@ -11,10 +11,30 @@ struct HelloTemplate<'a> {
     name: &'a str,
 }
 
+#[derive(Template)]
+#[template(path = "hello.txt")]
+struct HelloTextTemplate<'a> {
+    name: &'a str,
+}
+
 #[test]
 fn test_iron() {
     let rsp = Response::with((status::Ok, HelloTemplate { name: "world" }));
     let mut buf = Vec::new();
     let _ = rsp.body.unwrap().write_body(&mut buf);
     assert_eq!(buf, b"Hello, world!");
+
+    let content_type = rsp.headers.get::<iron::headers::ContentType>().unwrap();
+    assert_eq!(format!("{}", content_type), "text/html; charset=utf-8");
+}
+
+#[test]
+fn test_iron_non_html() {
+    let rsp = Response::with((status::Ok, HelloTextTemplate { name: "world" }));
+    let mut buf = Vec::new();
+    let _ = rsp.body.unwrap().write_body(&mut buf);
+    assert_eq!(buf, b"Hello, world!");
+
+    let content_type = rsp.headers.get::<iron::headers::ContentType>();
+    assert_eq!(content_type, None);
 }


### PR DESCRIPTION
I feel that it would be better to set Content-type header for html templates in Iron support.
Just like `askama_shared::input::EscapeMode`, the file extension is checked to determine whether the template is html or not. For html templates, I have added a code to add Content-type header in `modify` method.
I have also added the test to check this works properly.