### PR TITLE
`build = "build.rs"` is no longer necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ How to get started
 First, add the following to your crate's `Cargo.toml`:
 
 ```toml
-# in section [package]
-build = "build.rs"
-
 # in section [dependencies]
 askama = "0.5"
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -3,7 +3,6 @@ name = "askama_testing"
 version = "0.1.0"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 workspace = ".."
-build = "build.rs"
 
 [features]
 default = []


### PR DESCRIPTION
For all rust versions >= 1.19, cargo will assume `build = "build.rs"` if it sees a `build.rs` file in the same directory as the `Cargo.toml`