### PR TITLE
Fix the base template

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -103,7 +103,7 @@
 //! <!DOCTYPE html>
 //! <html lang="en">
 //!   <head>
-//!     <title>{{ block title %}{{ title }}{% endblock %} - My Site</title>
+//!     <title>{% block title %}{% endblock %} - My Site</title>
 //!     {% block head %}{% endblock %}
 //!   </head>
 //!   <body>


### PR DESCRIPTION
```{{ block title%}``` is simply invalid syntax and I have no idea what ```{{ title }}``` is for or how to make it work.

Probably a botched Copy-Paste-Job.