### PR TITLE
[WIP] Make "self" available to templates

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -147,7 +147,9 @@ impl<'a> Generator<'a> {
     }
 
     fn default<'n>() -> Generator<'n> {
-        Self::new(SetChain::new(), 0)
+        let mut chain = SetChain::new();
+        chain.insert("self");
+        Self::new(chain, 0)
     }
 
     fn child(&mut self) -> Generator {

--- a/testing/tests/methods.rs
+++ b/testing/tests/methods.rs
@@ -1,0 +1,59 @@
+#[macro_use]
+extern crate askama;
+
+use askama::Template;
+
+#[derive(Template)]
+#[template(source = "{{ self.get_s() }}", ext = "txt")]
+struct MethodTemplate<'a> {
+    s: &'a str,
+}
+
+impl<'a> MethodTemplate<'a> {
+    fn get_s(&self) -> &str {
+        self.s
+    }
+}
+
+#[derive(Template)]
+#[template(source = "{{ self.get_s() }} {{ t.get_s() }}", ext = "txt")]
+struct NestedMethodTemplate<'a> {
+    t: MethodTemplate<'a>,
+}
+
+impl<'a> NestedMethodTemplate<'a> {
+    fn get_s(&self) -> &str {
+        "bar"
+    }
+}
+
+#[derive(Template)]
+#[template(source = "{{ self.get_self() }}", ext = "txt")]
+struct SelfTemplate;
+
+impl SelfTemplate {
+    fn get_self(&self) -> &Self {
+        self
+    }
+}
+
+#[test]
+fn test_method() {
+    let t = MethodTemplate { s: "foo" };
+    assert_eq!(t.render().unwrap(), "foo");
+}
+
+#[test]
+fn test_nested() {
+    let t = NestedMethodTemplate {
+        t: MethodTemplate { s: "foo" },
+    };
+    assert_eq!(t.render().unwrap(), "bar foo");
+}
+
+// Fails with: thread 'test_self' has overflowed its stack
+#[test]
+fn test_self() {
+    let t = SelfTemplate;
+    assert_eq!(t.render().unwrap(), "");
+}


### PR DESCRIPTION
This PR makes it possible to call methods of the template context struct in templates.

An unresolved question is how to deal with potentially infinite recursion (causing stack overflow) as demonstrated by the test `test_self` in `methods.rs`.