### PR TITLE
Do not put a trailing comma after a block based match arm

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,3 @@
 brace_style = "PreferSameLine"
 fn_args_density = "Compressed"
-match_block_trailing_comma = true
 use_try_shorthand = true


### PR DESCRIPTION
You said:
> [`rustfmt` style says no commas after `{}` blocks in match arms.](https://github.com/djc/askama/pull/97#discussion_r199143221)

So let's configure it that way. See [match_block_trailing_comma](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md#match_block_trailing_comma).