### PR TITLE
Implement Responder trait for actix-web

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -22,12 +22,15 @@ default = []
 serde-json = ["askama_shared/serde-json"]
 with-iron = ["iron", "askama_derive/iron"]
 with-rocket = ["rocket", "askama_derive/rocket"]
+with-actix-web = ["actix-web", "askama_derive/actix-web", "mime_guess"]
 
 [dependencies]
 askama_derive = { path = "../askama_derive", version = "0.7.0" }
 askama_shared = { version = "0.7.0", path = "../askama_shared" }
 iron = { version = ">= 0.5, < 0.7", optional = true }
 rocket = { version = "0.3", optional = true }
+actix-web = { version = ">= 0.6", optional = true }
+mime_guess = { version = "2.0.0-alpha", optional = true }
 
 [package.metadata.docs.rs]
 features = [ "serde-json" ]

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -29,7 +29,7 @@ askama_derive = { path = "../askama_derive", version = "0.7.0" }
 askama_shared = { version = "0.7.0", path = "../askama_shared" }
 iron = { version = ">= 0.5, < 0.7", optional = true }
 rocket = { version = "0.3", optional = true }
-actix-web = { version = ">= 0.6", optional = true }
+actix-web = { version = "0.7", optional = true }
 mime_guess = { version = "2.0.0-alpha", optional = true }
 
 [package.metadata.docs.rs]

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -331,6 +331,10 @@ use std::path::Path;
 pub trait Template {
     /// Renders the template to the given `writer` buffer
     fn render_into(&self, writer: &mut std::fmt::Write) -> Result<()>;
+
+    /// Returns the given file extension
+    fn file_extension(&self) -> &str;
+
     /// Helper method which allocates a new `String` and renders into it
     fn render(&self) -> Result<String> {
         let mut buf = String::new();

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 default = []
 iron = ["askama_shared/iron"]
 rocket = ["askama_shared/rocket"]
+actix-web = ["askama_shared/actix-web"]
 
 [dependencies]
 askama_shared = { version = "0.7.0", path = "../askama_shared" }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -117,6 +117,15 @@ impl<'a> Generator<'a> {
         self.flush_ws(WS(false, false));
         self.writeln("Ok(())");
         self.writeln("}");
+
+        self.writeln("fn file_extension(&self) -> &str {"); 
+        let ext = match self.input.path.extension() {
+            Some(s) => s.to_str().unwrap(),
+            None => "txt",
+        };
+        self.writeln(&format!("{:?}", ext));
+        self.writeln("}");
+
         self.writeln("}");
     }
 

--- a/askama_shared/Cargo.toml
+++ b/askama_shared/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 serde-json = ["serde_json"]
 iron = []
 rocket = []
+actix-web = []
 
 [dependencies]
 serde = "1.0"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -9,15 +9,17 @@ default = []
 nightly = ["rocket", "rocket_codegen", "askama/with-rocket"]
 
 [dependencies]
-askama = { path = "../askama", version = "*", features = ["with-iron", "serde-json"] }
+askama = { path = "../askama", version = "*", features = ["iron", "serde-json"] }
 criterion = "0.2"
 iron = "0.6"
 rocket = { version = "0.3", optional = true }
 rocket_codegen = { version = "0.3", optional = true }
+actix-web = { version = "0.7", optional = true }
+bytes = { version = "0.4", optional = true }
 serde_json = "1.0"
 
 [build-dependencies]
-askama = { path = "../askama", version = "*", features = ["with-iron", "serde-json"] }
+askama = { path = "../askama", version = "*", features = ["iron", "serde-json"] }
 
 [[bench]]
 name = "all"

--- a/testing/tests/actix_web.rs
+++ b/testing/tests/actix_web.rs
@@ -1,0 +1,35 @@
+//#![cfg(feature = "actix-web")]
+
+#[macro_use]
+extern crate askama;
+extern crate actix_web;
+extern crate bytes;
+
+use bytes::Bytes;
+use askama::Template;
+use actix_web::test;
+use actix_web::HttpMessage;
+use actix_web::http::header::CONTENT_TYPE;
+
+#[derive(Template)]
+#[template(path = "hello.html")]
+struct HelloTemplate<'a> {
+    name: &'a str,
+}
+
+#[test]
+fn test_actix_web() {
+    let mut srv = test::TestServer::new(|app| {
+        app.handler(|_| HelloTemplate {
+            name: "world"
+        })
+    });
+
+    let request = srv.get().finish().unwrap();
+    let response = srv.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+    assert_eq!(response.headers().get(CONTENT_TYPE).unwrap(), "text/html");
+
+    let bytes = srv.execute(response.body()).unwrap();
+    assert_eq!(bytes, Bytes::from_static("Hello, world!".as_ref()));
+}


### PR DESCRIPTION
Heya!

Wound up needing this and figured I'd throw it over as a pull request. It's built for `actix-web` 0.7 which went out less than 12 hours ago, _but_ I originally built it against `0.6.x` and it should work there too ('s why I include the `mime_guess` crate rather than rely on `actix-web`'s `fs::{}` methods).

Test passes, but I couldn't figure out how you were opting to run against different web frameworks (Iron/Rocket/etc) so it needs to be enabled to run. Hoping this is the ~90% that lets you do the last 10% to make it correct per your package design, or something.

Cheers!