### PR TITLE
make `Template::extension()` static

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -395,8 +395,13 @@ pub trait Template {
     }
     /// Renders the template to the given `writer` buffer
     fn render_into(&self, writer: &mut std::fmt::Write) -> Result<()>;
-    /// Helper method to inspect the template's extension
-    fn extension(&self) -> Option<&str>;
+    /// Helper function to inspect the template's extension
+    fn extension() -> Option<&'static str>
+    where
+        Self: Sized,
+    {
+        None
+    }
 }
 
 pub use askama_derive::*;

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -107,7 +107,7 @@ impl<'a> Generator<'a> {
         buf.writeln("Ok(())");
         buf.writeln("}");
 
-        buf.writeln("fn extension(&self) -> Option<&str> {");
+        buf.writeln("fn extension() -> Option<&'static str> {");
         buf.writeln(&format!(
             "{:?}",
             self.input.path.extension().map(|s| s.to_str().unwrap())

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -27,7 +27,7 @@ fn test_variables() {
          Iñtërnâtiônàlizætiøn is important\n\
          in vars too: Iñtërnâtiônàlizætiøn"
     );
-    assert_eq!(s.extension(), Some("html"));
+    assert_eq!(VariablesTemplate::extension(), Some("html"));
 }
 
 #[derive(Template)]


### PR DESCRIPTION
It is useful for calculating the media type without instantiating the context value.