### PR TITLE
Add `indent` filter

### DIFF
--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -20,13 +20,14 @@ use escaping::{self, MarkupDisplay};
 // Askama or should refer to a local `filters` module. It should contain all the
 // filters shipped with Askama, even the optional ones (since optional inclusion
 // in the const vector based on features seems impossible right now).
-pub const BUILT_IN_FILTERS: [&str; 18] = [
+pub const BUILT_IN_FILTERS: [&str; 19] = [
     "abs",
     "capitalize",
     "center",
     "e",
     "escape",
     "format",
+    "indent",
     "join",
     "linebreaks",
     "linebreaksbr",
@@ -136,6 +137,25 @@ pub fn truncate(s: &fmt::Display, len: &usize) -> Result<String> {
         s.push_str("...");
         Ok(s)
     }
+}
+
+/// Indent lines with `width` spaces
+pub fn indent(s: &fmt::Display, width: &usize) -> Result<String> {
+    let s = format!("{}", s);
+
+    let mut indented = String::new();
+
+    for (i, c) in s.char_indices() {
+        indented.push(c);
+
+        if c == '\n' && i < s.len() - 1 {
+            for _ in 0..*width {
+                indented.push(' ');
+            }
+        }
+    }
+
+    Ok(indented)
 }
 
 /// Joins iterable into a string separated by provided argument
@@ -267,6 +287,17 @@ mod tests {
     #[test]
     fn test_trim() {
         assert_eq!(trim(&" Hello\tworld\t").unwrap(), "Hello\tworld");
+    }
+
+    #[test]
+    fn test_indent() {
+        assert_eq!(indent(&"hello", &2).unwrap(), "hello");
+        assert_eq!(indent(&"hello\n", &2).unwrap(), "hello\n");
+        assert_eq!(indent(&"hello\nfoo", &2).unwrap(), "hello\n  foo");
+        assert_eq!(
+            indent(&"hello\nfoo\n bar", &4).unwrap(),
+            "hello\n    foo\n     bar"
+        );
     }
 
     #[test]

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -87,7 +87,7 @@ pub fn format() {}
 /// A single newline becomes an HTML line break `<br>` and a new line
 /// followed by a blank line becomes a paragraph break `<p>`.
 pub fn linebreaks(s: &fmt::Display) -> Result<String> {
-    let s = format!("{}", s);
+    let s = s.to_string();
     let linebroken = s.replace("\n\n", "</p><p>").replace("\n", "<br/>");
 
     Ok(format!("<p>{}</p>", linebroken))
@@ -95,13 +95,13 @@ pub fn linebreaks(s: &fmt::Display) -> Result<String> {
 
 /// Converts all newlines in a piece of plain text to HTML line breaks
 pub fn linebreaksbr(s: &fmt::Display) -> Result<String> {
-    let s = format!("{}", s);
+    let s = s.to_string();
     Ok(s.replace("\n", "<br/>"))
 }
 
 /// Converts to lowercase
 pub fn lower(s: &fmt::Display) -> Result<String> {
-    let s = format!("{}", s);
+    let s = s.to_string();
     Ok(s.to_lowercase())
 }
 
@@ -112,7 +112,7 @@ pub fn lowercase(s: &fmt::Display) -> Result<String> {
 
 /// Converts to uppercase
 pub fn upper(s: &fmt::Display) -> Result<String> {
-    let s = format!("{}", s);
+    let s = s.to_string();
     Ok(s.to_uppercase())
 }
 
@@ -123,13 +123,13 @@ pub fn uppercase(s: &fmt::Display) -> Result<String> {
 
 /// Strip leading and trailing whitespace
 pub fn trim(s: &fmt::Display) -> Result<String> {
-    let s = format!("{}", s);
+    let s = s.to_string();
     Ok(s.trim().to_owned())
 }
 
 /// Limit string length, appends '...' if truncated
 pub fn truncate(s: &fmt::Display, len: &usize) -> Result<String> {
-    let mut s = format!("{}", s);
+    let mut s = s.to_string();
     if s.len() < *len {
         Ok(s)
     } else {
@@ -141,7 +141,7 @@ pub fn truncate(s: &fmt::Display, len: &usize) -> Result<String> {
 
 /// Indent lines with `width` spaces
 pub fn indent(s: &fmt::Display, width: &usize) -> Result<String> {
-    let s = format!("{}", s);
+    let s = s.to_string();
 
     let mut indented = String::new();
 
@@ -190,7 +190,7 @@ where
 
 /// Capitalize a value. The first character will be uppercase, all others lowercase.
 pub fn capitalize(s: &fmt::Display) -> Result<String> {
-    let mut s = format!("{}", s);
+    let mut s = s.to_string();
 
     match s.get_mut(0..1).map(|s| {
         s.make_ascii_uppercase();
@@ -211,7 +211,7 @@ pub fn capitalize(s: &fmt::Display) -> Result<String> {
 
 /// Centers the value in a field of a given width
 pub fn center(s: &fmt::Display, l: usize) -> Result<String> {
-    let s = format!("{}", s);
+    let s = s.to_string();
     let len = s.len();
 
     if l <= len {
@@ -238,7 +238,7 @@ pub fn center(s: &fmt::Display, l: usize) -> Result<String> {
 
 /// Count the words in that string
 pub fn wordcount(s: &fmt::Display) -> Result<usize> {
-    let s = format!("{}", s);
+    let s = s.to_string();
 
     Ok(s.split_whitespace().count())
 }


### PR DESCRIPTION
Add an `indent` filter with signature `indent(s, width)` that indents `s` with `width` spaces. Not sure if `width` is the best name, `indentation_width` might be better.