### PR TITLE
Fix off-by-one error with HTML escaping

### DIFF
--- a/askama_shared/src/escaping.rs
+++ b/askama_shared/src/escaping.rs
@@ -96,7 +96,7 @@ pub fn escape(s: String) -> String {
             _ => panic!("incorrect indexing"),
         }
     }
-    if start < bytes.len() - 1 {
+    if start < bytes.len() {
         res.extend(&bytes[start..]);
     }
 
@@ -112,5 +112,6 @@ mod tests {
         assert_eq!(escape("<&>".to_string()), "&lt;&amp;&gt;");
         assert_eq!(escape("bla&".to_string()), "bla&amp;");
         assert_eq!(escape("<foo".to_string()), "&lt;foo");
+        assert_eq!(escape("bla&h".to_string()), "bla&amp;h");
     }
 }


### PR DESCRIPTION
Here's a small fix for a corner case I ran into with HTML escaping.

If the second-to-last character of a string should be escaped,
but not the last, the last character was not being included in the
result.