### PR TITLE
Fix escape() to leverage Cow for performance

### DIFF
--- a/askama_shared/src/escaping.rs
+++ b/askama_shared/src/escaping.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+use std::convert::AsRef;
 use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, PartialEq)]
@@ -54,9 +56,13 @@ fn escapable(b: u8) -> bool {
     }
 }
 
-pub fn escape(s: String) -> String {
+pub fn escape<'a, S>(s: S) -> Cow<'a, str>
+where
+    S: Into<Cow<'a, str>>,
+{
+    let s = s.into();
     let mut found = Vec::new();
-    for (i, b) in s.as_bytes().iter().enumerate() {
+    for (i, b) in s.as_ref().as_bytes().iter().enumerate() {
         if escapable(*b) {
             found.push(i);
         }
@@ -100,7 +106,7 @@ pub fn escape(s: String) -> String {
         res.extend(&bytes[start..]);
     }
 
-    String::from_utf8(res).unwrap()
+    Cow::Owned(String::from_utf8(res).unwrap())
 }
 
 #[cfg(test)]

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -62,7 +62,9 @@ where
     MarkupDisplay<D>: From<I>,
 {
     let md: MarkupDisplay<D> = i.into();
-    Ok(MarkupDisplay::Safe(escaping::escape(md.unsafe_string())))
+    Ok(MarkupDisplay::Safe(
+        escaping::escape(md.unsafe_string()).to_string(),
+    ))
 }
 
 /// Alias for the `escape()` filter


### PR DESCRIPTION
@botika something like this is what I had in mind, though it seems to regress performance in a way that I don't quite understand.

```
Big table               time:   [1.7964 ms 1.8011 ms 1.8065 ms]
                        change: [+34.565% +35.906% +37.239%] (p = 0.00 < 0.05)
                        Performance has regressed.
Teams                   time:   [1.8405 us 1.8472 us 1.8575 us]
                        change: [+5.1616% +6.0817% +7.0624%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

However, if we're going to expose `escape()`, I definitely want it to accept `&str` types as input and return something with the same lifetime if no escaping is necessary. I think `Cow<str>` could be the way to do that, but maybe there is some other way (or there is overhead that I don't understand).

I've also thought about it some more, and I don't think I want to expose the existence of `askama_shared` as a public interface, so I'd either want to expose `escape()` as part of the `askama` interface (which seems like it might be a little bloated if you just need the escape function) or just turn it into another crate (could be just `askama-escape`, living in the same workspace).