### PR TITLE
Add simd optimized escape

### DIFF
--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -15,6 +15,9 @@ appveyor = { repository = "djc/askama" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "djc/askama" }
 
+[dependencies]
+v_htmlescape = "0.1"
+
 [dev-dependencies]
 criterion = "0.2"
 

--- a/askama_escape/benches/all.rs
+++ b/askama_escape/benches/all.rs
@@ -52,7 +52,6 @@ fn escaping(b: &mut criterion::Bencher) {
     justo.
 </p>"#;
     let string_short = "Lorem ipsum dolor sit amet,<foo>bar&foo\"bar\\foo/bar";
-    let empty = "";
     let no_escape = "Lorem ipsum dolor sit amet,";
     let no_escape_long = r#"
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque eu urna in aliquet.
@@ -71,7 +70,6 @@ quis lacus at, gravida maximus elit. Duis tristique, nisl nullam.
     b.iter(|| {
         format!("{}", MarkupDisplay::from(string_long));
         format!("{}", MarkupDisplay::from(string_short));
-        format!("{}", MarkupDisplay::from(empty));
         format!("{}", MarkupDisplay::from(no_escape));
         format!("{}", MarkupDisplay::from(no_escape_long));
     });


### PR DESCRIPTION
```
Escaping                time:   [2.1327 us 2.1333 us 2.1340 us]
                        change: [-57.511% -57.410% -57.333%] (p = 0.00 < 0.05)

Big table               time:   [756.68 us 757.40 us 758.59 us]
                        change: [-2.1775% +1.2301% +4.3756%] (p = 0.47 > 0.05)

Teams                   time:   [852.95 ns 853.39 ns 854.04 ns]
                        change: [+0.6336% +0.7563% +0.8888%] (p = 0.00 < 0.05)
```