### PR TITLE
 Add specialization and optimize

### DIFF
--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -15,6 +15,9 @@ appveyor = { repository = "djc/askama" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "djc/askama" }
 
+[dependencies]
+v_htmlescape = "0.1"
+
 [dev-dependencies]
 criterion = "0.2"
 

--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -16,7 +16,11 @@ maintenance = { status = "actively-developed" }
 travis-ci = { repository = "djc/askama" }
 
 [dependencies]
+cfg-if = "0.1"
 v_htmlescape = "0.1"
+
+[build-dependencies]
+version_check = "0.1"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/askama_escape/benches/all.rs
+++ b/askama_escape/benches/all.rs
@@ -52,7 +52,6 @@ fn escaping(b: &mut criterion::Bencher) {
     justo.
 </p>"#;
     let string_short = "Lorem ipsum dolor sit amet,<foo>bar&foo\"bar\\foo/bar";
-    let empty = "";
     let no_escape = "Lorem ipsum dolor sit amet,";
     let no_escape_long = r#"
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque eu urna in aliquet.
@@ -71,7 +70,6 @@ quis lacus at, gravida maximus elit. Duis tristique, nisl nullam.
     b.iter(|| {
         format!("{}", MarkupDisplay::from(string_long));
         format!("{}", MarkupDisplay::from(string_short));
-        format!("{}", MarkupDisplay::from(empty));
         format!("{}", MarkupDisplay::from(no_escape));
         format!("{}", MarkupDisplay::from(no_escape_long));
     });

--- a/askama_escape/build.rs
+++ b/askama_escape/build.rs
@@ -1,0 +1,11 @@
+extern crate version_check;
+
+fn main() {
+    match version_check::is_nightly() {
+        Some(true) => {
+            println!("cargo:rustc-cfg=askama_nightly");
+        }
+        Some(false) => (),
+        None => (),
+    };
+}

--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(askama_nightly, feature(specialization))]
+
+#[macro_use]
+extern crate cfg_if;
 extern crate v_htmlescape;
 
 use std::fmt::{self, Display, Formatter};
@@ -14,6 +18,126 @@ where
     Unsafe(T),
 }
 
+cfg_if! {
+    if #[cfg(askama_nightly)] {
+
+        pub trait ANum {}
+
+        macro_rules! trait_impl {
+            ($name:ident for $($t:ty)*) => ($(
+                impl $name for $t {
+                }
+            )*)
+        }
+
+        // TODO: MarkupDisplay::from parameter, check number of borrow's
+        trait_impl!(ANum for usize u8 u16 u32 u64 isize i8 i16 i32 i64);
+        trait_impl!(ANum for &usize &u8 &u16 &u32 &u64 &isize &i8 &i16 &i32 &i64);
+        trait_impl!(ANum for &&usize &&u8 &&u16 &&u32 &&u64 &&isize &&i8 &&i16 &&i32 &&i64);
+
+        #[cfg(has_i128)]
+        trait_impl!(ANum for u128 i128);
+        #[cfg(has_i128)]
+        trait_impl!(ANum for &u128 &i128);
+        #[cfg(has_i128)]
+        trait_impl!(ANum for &&u128 &&i128);
+
+        impl<T> From<T> for MarkupDisplay<T>
+        where
+            T: Display,
+        {
+            default fn from(t: T) -> MarkupDisplay<T> {
+                MarkupDisplay::Unsafe(t)
+            }
+        }
+
+        impl<T> From<T> for MarkupDisplay<T>
+        where
+            T: Display + ANum,
+        {
+            fn from(t: T) -> MarkupDisplay<T> {
+                MarkupDisplay::Safe(t)
+            }
+        }
+
+        impl<T> Display for MarkupDisplay<T>
+        where
+            T: Display,
+        {
+            default fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+                match *self {
+                    MarkupDisplay::Unsafe(ref t) => escape(&t.to_string()).fmt(f),
+                    MarkupDisplay::Safe(ref t) => t.fmt(f),
+                }
+            }
+        }
+
+        pub trait IsStr {
+            fn cow(&self) -> &str;
+        }
+
+        macro_rules! string_trait_impl {
+            ($($t:ty)*) => ($(
+                impl IsStr for $t {
+                    #[inline]
+                    fn cow(&self) -> &str {
+                        &self
+                    }
+                }
+            )*)
+        }
+
+        string_trait_impl!(String &String &&String);
+
+        macro_rules! str_trait_impl {
+            ($($t:ty)*) => ($(
+                impl IsStr for $t {
+                    #[inline]
+                    fn cow(&self) -> &str {
+                        self
+                    }
+                }
+            )*)
+        }
+
+        str_trait_impl!(&str &&str &&&str);
+
+        impl<T> Display for MarkupDisplay<T>
+        where
+            T: Display + IsStr,
+        {
+            fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+                match *self {
+                    MarkupDisplay::Unsafe(ref t) => escape(t.cow()).fmt(f),
+                    MarkupDisplay::Safe(ref t) => t.fmt(f),
+                }
+            }
+        }
+    } else {
+
+        impl<T> From<T> for MarkupDisplay<T>
+        where
+            T: Display,
+        {
+            fn from(t: T) -> MarkupDisplay<T> {
+                MarkupDisplay::Unsafe(t)
+            }
+        }
+
+        impl<T> Display for MarkupDisplay<T>
+        where
+            T: Display,
+        {
+            fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+                match *self {
+                    MarkupDisplay::Unsafe(ref t) => escape(&t.to_string()).fmt(f),
+                    MarkupDisplay::Safe(ref t) => t.fmt(f),
+                }
+            }
+        }
+    }
+}
+
 impl<T> MarkupDisplay<T>
 where
     T: Display,
@@ -22,27 +146,6 @@ where
         match self {
             MarkupDisplay::Unsafe(t) => MarkupDisplay::Safe(t),
             _ => self,
-        }
-    }
-}
-
-impl<T> From<T> for MarkupDisplay<T>
-where
-    T: Display,
-{
-    fn from(t: T) -> MarkupDisplay<T> {
-        MarkupDisplay::Unsafe(t)
-    }
-}
-
-impl<T> Display for MarkupDisplay<T>
-where
-    T: Display,
-{
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match *self {
-            MarkupDisplay::Unsafe(ref t) => escape(&t.to_string()).fmt(f),
-            MarkupDisplay::Safe(ref t) => t.fmt(f),
         }
     }
 }

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -62,21 +62,23 @@ where
 }
 
 /// Escapes `&`, `<` and `>` in strings
+#[allow(unused_variables)]
 pub fn escape<D, I>(i: I) -> Result<MarkupDisplay<D>>
 where
     D: fmt::Display,
     MarkupDisplay<D>: From<I>,
 {
-    Ok(i.into())
+    unreachable!()
 }
 
 /// Alias for the `escape()` filter
+#[allow(unused_variables)]
 pub fn e<D, I>(i: I) -> Result<MarkupDisplay<D>>
 where
     D: fmt::Display,
     MarkupDisplay<D>: From<I>,
 {
-    escape(i)
+    unreachable!()
 }
 
 /// Returns adequate string representation (in KB, ..) of number of bytes


### PR DESCRIPTION
RFC
at nightly
```
Escaping                time:   [1.6821 us 1.6825 us 1.6828 us]
                        change: [-65.188% -65.075% -64.985%] (p = 0.00 < 0.05)
Big table               time:   [283.14 us 283.19 us 283.24 us]
                        change: [-56.530% -56.514% -56.497%] (p = 0.00 < 0.05)
Teams                   time:   [463.01 ns 463.41 ns 463.89 ns]
                        change: [-47.048% -46.984% -46.887%] (p = 0.00 < 0.05)
```