### PR TITLE
Fix support for tuple

### DIFF
--- a/askama_derive/src/parser.rs
+++ b/askama_derive/src/parser.rs
@@ -276,23 +276,6 @@ named!(target_single<Input, Target>, map!(identifier,
     |s| Target::Name(s)
 ));
 
-named!(target_plural<Input, Target>, do_parse!(
-    args: do_parse!(
-        arg0: ws!(identifier) >>
-        args: many1!(do_parse!(
-            tag!(",") >>
-            argn: ws!(identifier) >>
-            (argn)
-        )) >>
-        ({
-           let mut res = vec![arg0];
-           res.extend(args);
-           res
-        })
-    ) >>
-    (Target::Tuple(args))
-));
-
 named!(target_tuple<Input, Target>, do_parse!(
     tag!("(") >>
     args: opt!(do_parse!(
@@ -758,7 +741,7 @@ named!(block_let<Input, Node>, do_parse!(
 named_args!(block_for<'a>(s: &'a Syntax<'a>) <Input<'a>, Node<'a>>, do_parse!(
     pws1: opt!(tag!("-")) >>
     ws!(tag!("for")) >>
-    var: ws!(alt!(target_plural | target_single | target_tuple)) >>
+    var: ws!(alt!(target_single | target_tuple)) >>
     ws!(tag!("in")) >>
     iter: ws!(expr_any) >>
     nws1: opt!(tag!("-")) >>

--- a/askama_derive/src/parser.rs
+++ b/askama_derive/src/parser.rs
@@ -291,7 +291,7 @@ named!(target_tuple<Input, Target>, do_parse!(
            res
         })
     )) >>
-    opt!(tag!(",")) >>
+    opt!(ws!(tag!(","))) >>
     tag!(")") >>
     (Target::Tuple(args.unwrap_or_default()))
 ));

--- a/testing/templates/for.html
+++ b/testing/templates/for.html
@@ -4,6 +4,3 @@
 {% for (s1, s2,) in tuple_strings %}
   {{- loop.index0 }}. {{ s1 }},{{ s2 }}{% if loop.first %} (first){% endif %}
 {% endfor %}
-{% for s1, s2 in tuple_strings %}
-  {{- loop.index0 }}. {{ s1 }},{{ s2 }}
-{% endfor %}

--- a/testing/templates/for.html
+++ b/testing/templates/for.html
@@ -1,6 +1,9 @@
 {% for s in strings %}
   {{- loop.index0 }}. {{ s }}{% if loop.first %} (first){% endif %}
 {% endfor %}
-{% for (s1, s2) in tuple_strings %}
+{% for (s1, s2,) in tuple_strings %}
   {{- loop.index0 }}. {{ s1 }},{{ s2 }}{% if loop.first %} (first){% endif %}
+{% endfor %}
+{% for s1, s2 in tuple_strings %}
+  {{- loop.index0 }}. {{ s1 }},{{ s2 }}
 {% endfor %}

--- a/testing/templates/for.html
+++ b/testing/templates/for.html
@@ -1,6 +1,6 @@
 {% for s in strings %}
   {{- loop.index0 }}. {{ s }}{% if loop.first %} (first){% endif %}
 {% endfor %}
-{% for (s1, s2,) in tuple_strings %}
+{% for (s1, s2, ) in tuple_strings %}
   {{- loop.index0 }}. {{ s1 }},{{ s2 }}{% if loop.first %} (first){% endif %}
 {% endfor %}

--- a/testing/tests/loops.rs
+++ b/testing/tests/loops.rs
@@ -15,7 +15,7 @@ fn test_for() {
     };
     assert_eq!(
         s.render().unwrap(),
-        "0. A (first)\n1. alfa\n2. 1\n\n0. B,beta (first)\n\n0. B,beta\n"
+        "0. A (first)\n1. alfa\n2. 1\n\n0. B,beta (first)\n"
     );
 }
 

--- a/testing/tests/loops.rs
+++ b/testing/tests/loops.rs
@@ -15,7 +15,7 @@ fn test_for() {
     };
     assert_eq!(
         s.render().unwrap(),
-        "0. A (first)\n1. alfa\n2. 1\n\n0. B,beta (first)\n"
+        "0. A (first)\n1. alfa\n2. 1\n\n0. B,beta (first)\n\n0. B,beta\n"
     );
 }
 


### PR DESCRIPTION
Thank you for your previous approval!

I fixed it for Jinja style, like so:
`{% for s1, s2 in tuple_strings %}`

And supported trailing comma for something like auto generated templates.