### PR TITLE
Use include_bytes macro to avoid the need for a build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,23 +68,8 @@ First, add the following to your crate's `Cargo.toml`:
 
 ```toml
 # in section [dependencies]
-askama = "0.7"
+askama = "0.8"
 
-# in section [build-dependencies]
-askama = "0.7"
-```
-
-Because Askama will generate Rust code from your template files,
-the crate will need to be recompiled when your templates change.
-This is supported by adding a build script, `build.rs`, to your crate.
-It needs askama as a build dependency:
-
-```rust
-extern crate askama;
-
-fn main() {
-    askama::rerun_if_templates_changed();
-}
 ```
 
 Now create a directory called `templates` in your crate root.

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -515,35 +515,8 @@ pub mod gotham {
     }
 }
 
-fn visit_dirs(dir: &Path, cb: &dyn Fn(&DirEntry)) -> io::Result<()> {
-    if dir.is_dir() {
-        for entry in fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                visit_dirs(&path, cb)?;
-            } else {
-                cb(&entry);
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Build script helper to rebuild crates if contained templates have changed
+/// Old build script helper to rebuild crates if contained templates have changed
 ///
-/// Iterates over all files in the template directories and writes a
-/// `cargo:rerun-if-changed=` line for each of them to stdout.
-///
-/// This helper method can be used in build scripts (`build.rs`) in crates
-/// that have templates, to make sure the crate gets rebuilt when template
-/// source code changes.
-pub fn rerun_if_templates_changed() {
-    let file = read_config_file();
-    for template_dir in &shared::Config::new(&file).dirs {
-        visit_dirs(template_dir, &|e: &DirEntry| {
-            println!("cargo:rerun-if-changed={}", e.path().to_str().unwrap());
-        })
-        .unwrap();
-    }
-}
+/// This function is now deprecated and does nothing.
+#[deprecated(since="0.8.1", note="file-level dependency tracking is handled automatically without build script")]
+pub fn rerun_if_templates_changed() {}

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -25,9 +25,6 @@ gotham = { version = "0.3", optional = true }
 mime = { version = "0.3", optional = true }
 hyper = { version = "0.12", optional = true }
 
-[build-dependencies]
-askama = { path = "../askama", version = "*" }
-
 [dev-dependencies]
 criterion = "0.2"
 

--- a/testing/build.rs
+++ b/testing/build.rs
@@ -1,5 +1,0 @@
-use askama;
-
-fn main() {
-    askama::rerun_if_templates_changed();
-}


### PR DESCRIPTION
This PR adds an otherwise unused `include_bytes!(...);` statement in the generated template code for each template in the context map and for each included template. This allows the compiler to detect file level dependencies without the need for a custom build script.

I believe I caught all the relevant file dependencies: extends, imports, includes and of course the template itself (if it is backed by a file, which requires some checks).

This gives more granular file-level dependency information than the build script, although I don't believe that actually gives any practical benefits right now.

Feedback welcome.

