### PR TITLE
Add TemplateResponder trait for integration with actix-web

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -492,6 +492,21 @@ pub mod actix_web {
         let ctype = get_mime_type(ext).to_string();
         Ok(HttpResponse::Ok().content_type(ctype.as_str()).body(rsp))
     }
+
+    pub trait TemplateResponder {
+        fn responder(&self) -> Result<HttpResponse, Error>;
+    }
+
+    impl<T: super::Template> TemplateResponder for T {
+        fn responder(&self) -> Result<HttpResponse, Error> {
+            let rsp = self
+                .render()
+                .map_err(|_| ErrorInternalServerError("Template render error"))?;
+            let ext = T::extension().unwrap_or("");
+            let ctype = get_mime_type(ext).to_string();
+            Ok(HttpResponse::Ok().content_type(ctype.as_str()).body(rsp))
+        }
+    }
 }
 
 #[cfg(feature = "with-gotham")]
@@ -522,5 +537,8 @@ pub mod gotham {
 /// Old build script helper to rebuild crates if contained templates have changed
 ///
 /// This function is now deprecated and does nothing.
-#[deprecated(since="0.8.1", note="file-level dependency tracking is handled automatically without build script")]
+#[deprecated(
+    since = "0.8.1",
+    note = "file-level dependency tracking is handled automatically without build script"
+)]
 pub fn rerun_if_templates_changed() {}

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -502,7 +502,7 @@ pub mod actix_web {
             let rsp = self
                 .render()
                 .map_err(|_| ErrorInternalServerError("Template render error"))?;
-            let ext = T::extension().unwrap_or("");
+            let ext = T::extension().unwrap_or("txt");
             let ctype = get_mime_type(ext).to_string();
             Ok(HttpResponse::Ok().content_type(ctype.as_str()).body(rsp))
         }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -117,9 +117,12 @@ impl<'a> Generator<'a> {
             };
             if path_is_valid {
                 let path = path.to_str().unwrap();
-                buf.writeln(&quote! {
-                    include_bytes!(#path);
-                }.to_string());
+                buf.writeln(
+                    &quote! {
+                        include_bytes!(#path);
+                    }
+                    .to_string(),
+                );
             }
         }
 
@@ -624,9 +627,12 @@ impl<'a> Generator<'a> {
         // Make sure the compiler understands that the generated code depends on the template file.
         {
             let path = path.to_str().unwrap();
-            buf.writeln(&quote! {
-                include_bytes!(#path);
-            }.to_string());
+            buf.writeln(
+                &quote! {
+                    include_bytes!(#path);
+                }
+                .to_string(),
+            );
         }
 
         let size_hint = {

--- a/testing/tests/actix_web.rs
+++ b/testing/tests/actix_web.rs
@@ -2,7 +2,7 @@
 use actix_web::http::header::CONTENT_TYPE;
 use actix_web::test;
 use actix_web::HttpMessage;
-use askama::Template;
+use askama::{actix_web::TemplateResponder, Template};
 use bytes::Bytes;
 
 #[derive(Template)]
@@ -14,6 +14,24 @@ struct HelloTemplate<'a> {
 #[test]
 fn test_actix_web() {
     let mut srv = test::TestServer::new(|app| app.handler(|_| HelloTemplate { name: "world" }));
+
+    let request = srv.get().finish().unwrap();
+    let response = srv.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+    assert_eq!(response.headers().get(CONTENT_TYPE).unwrap(), "text/html");
+
+    let bytes = srv.execute(response.body()).unwrap();
+    assert_eq!(bytes, Bytes::from_static("Hello, world!".as_ref()));
+}
+
+#[test]
+fn test_actix_web_responder() {
+    let mut srv = test::TestServer::new(|app| {
+        app.handler(|_| {
+            let name = "world".to_owned();
+            HelloTemplate { name: &name }.responder()
+        })
+    });
 
     let request = srv.get().finish().unwrap();
     let response = srv.execute(request.send()).unwrap();


### PR DESCRIPTION
This is similar to what `actix_web::AsyncResponder` does. It enables us to call `.responder()` on a template to render it into an `actix_web::HttpResponse`. This is advantageous over the current approach (implementing `actix_web::Responder` for `T: Template`) because the current approach doesn't allow returning templates with references to local variables. Please see the added test for what I mean.