### PR TITLE
Make html-escaper also escape .j2, .jinja and .jinja2 files

### DIFF
--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -226,6 +226,7 @@ static DEFAULT_SYNTAX_NAME: &str = "default";
 static DEFAULT_ESCAPERS: &[(&[&str], &str)] = &[
     (&["html", "htm", "xml"], "::askama::Html"),
     (&["none", "txt", ""], "::askama::Text"),
+    (&["j2", "jinja", "jinja2"], "::askama::Html"),
 ];
 
 #[cfg(test)]
@@ -404,6 +405,7 @@ mod tests {
                 (str_set(&["js"]), "::askama::Js".into()),
                 (str_set(&["html", "htm", "xml"]), "::askama::Html".into()),
                 (str_set(&["none", "txt", ""]), "::askama::Text".into()),
+                (str_set(&["j2", "jinja", "jinja2"]), "::askama::Html".into()),
             ]
         );
     }


### PR DESCRIPTION
The content of for .j2, .jinja and .jinja2 files shouldn't be anything else than HTML and Jinja syntax, so i just used the existing html-escaper for these file types.

I did this because i'm developing with VS Code and am using the [Better Jinja](https://marketplace.visualstudio.com/items?itemName=samuelcolvin.jinjahtml)-Extension which provides syntax highlighting for jinja(2) including HTML, Markdown and YAML templates.

I hope this is ok for you or should i add a dedicated `::askama::Jinja` function which directly calls `::askama::Html`?