### PR TITLE
Fully qualified Result

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -228,7 +228,7 @@ impl<'a> Generator<'a> {
         buf.writeln("type Error = ::askama::actix_web::Error;");
         buf.writeln(
             "fn respond_to<S>(self, _req: &::askama::actix_web::HttpRequest<S>) \
-             -> Result<Self::Item, Self::Error> {",
+             -> ::std::result::Result<Self::Item, Self::Error> {",
         );
 
         let ext = match self.input.path.extension() {


### PR DESCRIPTION
This fixes a "wrong number of type arguments" error if the point of inclusion defines its own Result with a specific type.