### PR TITLE
Default to UTF-8 mime type for actix-web and gotham

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -24,8 +24,8 @@ serde-json = ["askama_shared/serde_json"]
 serde-yaml = ["askama_shared/serde_yaml"]
 with-iron = ["iron", "askama_derive/iron"]
 with-rocket = ["rocket", "askama_derive/rocket"]
-with-actix-web = ["actix-web", "askama_derive/actix-web", "mime_guess"]
-with-gotham = ["gotham", "askama_derive/gotham", "hyper", "mime_guess"]
+with-actix-web = ["actix-web", "askama_derive/actix-web", "mime", "mime_guess"]
+with-gotham = ["gotham", "askama_derive/gotham", "hyper", "mime", "mime_guess"]
 
 [dependencies]
 askama_derive = { version = "0.8.0", path = "../askama_derive" }
@@ -34,6 +34,7 @@ askama_shared = { version = "0.8.0", path = "../askama_shared" }
 iron = { version = ">= 0.5, < 0.7", optional = true }
 rocket = { version = "0.4", optional = true }
 actix-web = { version = "0.7", optional = true }
+mime = { version = "0.3", optional = true }
 mime_guess = { version = "2.0.0-alpha", optional = true }
 gotham = { version = "0.3", optional = true }
 hyper = { version = "0.12", optional = true }

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -486,10 +486,29 @@ pub mod rocket {
     }
 }
 
+#[cfg(feature = "mime_guess")]
+fn get_mime_type(ext: &str) -> mime_guess::Mime {
+    let basic_type = mime_guess::get_mime_type(ext);
+    if basic_type == mime::TEXT_PLAIN {
+        mime::TEXT_PLAIN_UTF_8
+    } else if basic_type == mime::TEXT_HTML {
+        mime::TEXT_HTML_UTF_8
+    } else if basic_type == mime::TEXT_CSS {
+         mime::TEXT_CSS_UTF_8
+    } else if basic_type == mime::TEXT_CSV {
+         mime::TEXT_CSV_UTF_8
+    } else if basic_type == mime::TEXT_TAB_SEPARATED_VALUES {
+         mime::TEXT_TAB_SEPARATED_VALUES_UTF_8
+    } else if basic_type == mime::APPLICATION_JAVASCRIPT {
+         mime::APPLICATION_JAVASCRIPT_UTF_8
+    } else {
+        basic_type
+    }
+}
+
 #[cfg(feature = "with-actix-web")]
 pub mod actix_web {
     extern crate actix_web;
-    extern crate mime_guess;
 
     // actix_web technically has this as a pub fn in later versions, fs::file_extension_to_mime.
     // Older versions that don't have it exposed are easier this way. If ext is empty or no
@@ -498,7 +517,6 @@ pub mod actix_web {
     pub use self::actix_web::{
         error::ErrorInternalServerError, Error, HttpRequest, HttpResponse, Responder,
     };
-    use self::mime_guess::get_mime_type;
 
     pub trait TemplateIntoResponse {
         fn into_response(&self) -> Result<HttpResponse, Error>;
@@ -509,7 +527,7 @@ pub mod actix_web {
             let rsp = self
                 .render()
                 .map_err(|_| ErrorInternalServerError("Template parsing error"))?;
-            let ctype = get_mime_type(T::extension().unwrap_or("txt")).to_string();
+            let ctype = super::get_mime_type(T::extension().unwrap_or("txt")).to_string();
             Ok(HttpResponse::Ok().content_type(ctype.as_str()).body(rsp))
         }
     }
@@ -521,10 +539,9 @@ pub mod gotham {
     use gotham::helpers::http::response::{create_empty_response, create_response};
     pub use gotham::state::State;
     pub use hyper::{Body, Response, StatusCode};
-    use mime_guess::get_mime_type;
 
     pub fn respond<T: super::Template>(t: &T, ext: &str) -> Response<Body> {
-        let mime_type = get_mime_type(ext).to_string();
+        let mime_type = super::get_mime_type(ext).to_string();
 
         match t.render() {
             Ok(body) => Response::builder()

--- a/testing/tests/actix_web.rs
+++ b/testing/tests/actix_web.rs
@@ -18,7 +18,7 @@ fn test_actix_web() {
     let request = srv.get().finish().unwrap();
     let response = srv.execute(request.send()).unwrap();
     assert!(response.status().is_success());
-    assert_eq!(response.headers().get(CONTENT_TYPE).unwrap(), "text/html");
+    assert_eq!(response.headers().get(CONTENT_TYPE).unwrap(), "text/html; charset=utf-8");
 
     let bytes = srv.execute(response.body()).unwrap();
     assert_eq!(bytes, Bytes::from_static("Hello, world!".as_ref()));

--- a/testing/tests/gotham.rs
+++ b/testing/tests/gotham.rs
@@ -31,7 +31,7 @@ fn test_gotham() {
         let content_type = headers
             .get("content-type")
             .expect("Response did not contain content-type header");
-        assert_eq!(content_type.to_str().unwrap(), mime::TEXT_HTML.to_string());
+        assert_eq!(content_type.to_str().unwrap(), mime::TEXT_HTML_UTF_8.to_string());
     }
 
     let body = res.read_utf8_body().expect("failed to read response body");


### PR DESCRIPTION
Fixes issue #209 for actix-web and gotham. Rocket uses its own internal Content function, so I left it alone. Also fixed the tests in askama_testing, which are what I used to validate the change.

NB I had to use if statements instead of match due to limitations of the mime type. I don't know why they're there.