### PR TITLE
Don't force adding "&" to start of collection for TemplateLoop

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -296,6 +296,10 @@
 //! * *loop.index0*: current loop iteration (starting from 0)
 //! * *loop.first*: whether this is the first iteration of the loop
 //! * *loop.last*: whether this is the last iteration of the loop
+//! 
+//! Loops should be passed references to collections so that they are not 
+//! consumed by the template. If the template struct owns the collection that is 
+//! being passed to a loop, make sure to prefix the collection with an `&`.
 //!
 //! ### If
 //!

--- a/askama_derive/src/parser.rs
+++ b/askama_derive/src/parser.rs
@@ -11,6 +11,7 @@ pub enum Expr<'a> {
     NumLit(&'a str),
     StrLit(&'a str),
     Var(&'a str),
+    RefVar(&'a str),
     Path(Vec<&'a str>),
     Array(Vec<Expr<'a>>),
     Attr(Box<Expr<'a>>, &'a str),
@@ -245,6 +246,11 @@ named!(param_str_lit<Input, MatchParameter>, map!(
     |s| MatchParameter::StrLit(str::from_utf8(&s).unwrap())
 ));
 
+named!(expr_ref_var<Input, Expr>, preceded!(
+    tag!("&"), map!(identifier, |s| Expr::RefVar(s))
+));
+
+
 named!(expr_var<Input, Expr>, map!(identifier,
     |s| Expr::Var(s))
 );
@@ -455,6 +461,7 @@ named!(expr_single<Input, Expr>, alt!(
     expr_str_lit |
     expr_path |
     expr_array_lit |
+    expr_ref_var |
     expr_var |
     expr_group
 ));


### PR DESCRIPTION
Currently the TemplateLoop generator always appends `&` to every expression. This is inconvenient as it doesn't allow iteration over collections that are not owned by a struct but are passed by reference. 

For example today this does not work: 

welcome.rs
```
#[derive(Template)]
#[template(path = "apps/welcome/welcome.html")]
struct Landing<'a> {
    locales: &'a HashMap<String, Locale>,
}

pub fn index(req: HttpRequest<AppState>) -> Result<HttpResponse, Error> {

    let locales = &req.state().locales;

    let landing = Landing {
        locales: locales,
    };

    landing.respond_to(&req)
}

```

welcome.html
```
<h1>Welcome!</h1>
<div>
    {% for locale in locales.values() %}
        <p>
            <a hreflang="{{ locale.key }}" href="/{{ locale.key }}/">{{ locale.description }}</a>
        </p>
    {% endfor %}
</div>
```
This code will produce a cannot move out of borrowed context error. 

The current work around is: 
welcome.rs
```
#[derive(Template)]
#[template(path = "apps/welcome/welcome.html", print = "all")]
struct Landing<'a> {
    locales: &'a HashMap<String, Locale>,
}

// TODO: Delete after upgrading askama
struct LocaleAskama<'a> {
    description: &'a str,
    key: &'a str,
}

pub fn index(req: HttpRequest<AppState>) -> Result<HttpResponse, Error> {

    let locales = &req.state().locales;
    let mut locales_parsed = Vec::<LocaleAskama>::new();

    for locale in locales.values() {
        locales_parsed.push(LocaleAskama{
            description: locale.description.as_str(),
            key: locale.key.as_str(),
        });
    } 

    let landing = Landing {
        locales: locales_parsed,
    };

    landing.respond_to(&req)
}
```

The bad thing is that this would be a breaking change as it would require collections that are owned by the template to have the & prefix. I think this should be the correct pattern, I couldn't figure out any other way to check of the template field was a reference or owned. 

Also, I noticed there is no CHANGELOG.md file, I can create one if you think it's a good idea. 