### PR TITLE
Improve actix-web integration by creating bytes buffer instead of string

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -24,7 +24,7 @@ serde-json = ["askama_shared/serde_json"]
 serde-yaml = ["askama_shared/serde_yaml"]
 with-iron = ["iron", "askama_derive/iron"]
 with-rocket = ["rocket", "askama_derive/rocket"]
-with-actix-web = ["actix-web", "askama_derive/actix-web", "mime_guess"]
+with-actix-web = ["actix-web", "askama_derive/actix-web", "mime_guess", "bytes"]
 with-gotham = ["gotham", "askama_derive/gotham", "hyper", "mime_guess"]
 
 [dependencies]
@@ -37,6 +37,7 @@ actix-web = { version = "0.7", optional = true }
 mime_guess = { version = "2.0.0-alpha", optional = true }
 gotham = { version = "0.3", optional = true }
 hyper = { version = "0.12", optional = true }
+bytes = { version = "0.4", optional = true }
 
 [package.metadata.docs.rs]
 features = [ "serde-json" ]

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -500,9 +500,9 @@ pub mod actix_web {
 
     impl BytesWriter {
         #[inline]
-        pub fn new() -> Self {
+        pub fn with_capacity(size: usize) -> Self {
             Self {
-                buf: bytes::BytesMut::with_capacity(4096)
+                buf: bytes::BytesMut::with_capacity(size)
             }
         }
 
@@ -510,7 +510,6 @@ pub mod actix_web {
         pub fn freeze(self) -> bytes::Bytes {
             self.buf.freeze()
         }
-
     }
 
     impl fmt::Write for BytesWriter {
@@ -536,7 +535,7 @@ pub mod actix_web {
 
     impl<T: super::Template> TemplateIntoResponse for T {
         fn into_response(&self) -> Result<HttpResponse, Error> {
-            let mut buffer = BytesWriter::new();
+            let mut buffer = BytesWriter::with_capacity(T::size_hint());
             self.render_into(&mut buffer)
                 .map_err(|_| ErrorInternalServerError("Template parsing error"))?;
 


### PR DESCRIPTION
It removes small overhead of converting from `Vec<u8>` to `Bytes`