### PR TITLE
Fix doc for using custom filters

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -172,9 +172,8 @@
 //! [filters module documentation](filters/index.html).
 //!
 //! To define your own filters, simply have a module named `filters` in
-//! scope of the context deriving a `Template` `impl`. Any filter names
-//! that are not part of the built-in filters will be referenced through
-//! the `filters::` prefix.
+//! scope of the context deriving a `Template` `impl`. Note that in case of
+//! name collision, the built in filters take precedence.
 //!
 //! ## Whitespace control
 //!


### PR DESCRIPTION
Contrary to what is stated in the doc, custom filters aren't accessed by prepending `filters::` in the templates. I fixed the documentation given what I read [in the code](https://github.com/djc/askama/blob/23ff7ad636b4c0e26d3242747d50b7123831a1a8/askama_derive/src/generator.rs#L940).