### PR TITLE
Improve parsing of a 'raw' block

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -402,6 +402,20 @@
 //!
 //! Askama supports block comments delimited by `{#` and `#}`.
 //!
+//! ## Raw
+//!
+//! Makes Askama to ignore parts it would otherwise handle as template control structures.
+//!
+//! ```text
+//! {% raw %}
+//!   {% block name %}
+//!     {% for row in table %}
+//!       <tr>{% for col in row %}<td>{{ col|escape }}</td>{% endfor %}</tr>
+//!     {% endfor %}
+//!   {% endblock %}
+//! {% endraw %}
+//! ```
+//!
 //! # Optional functionality
 //!
 //! ## Rocket integration

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -345,10 +345,9 @@ impl<'a> Generator<'a> {
                     self.flush_ws(m.ws1);
                     self.prepare_ws(m.ws2);
                 }
-                Node::Raw(ws1, contents, ws2) => {
+                Node::Raw(ws1, contents, _) => {
                     self.handle_ws(ws1);
                     self.buf_writable.push(Writable::Lit(contents));
-                    self.handle_ws(ws2);
                 }
                 Node::Import(ws, _, _) => {
                     if level != AstLevel::Top {

--- a/askama_derive/src/parser.rs
+++ b/askama_derive/src/parser.rs
@@ -838,20 +838,34 @@ named_args!(block_macro<'a>(s: &'a Syntax<'a>) <Input<'a>, Node<'a>>, do_parse!(
     })
 ));
 
+fn take_raw_block<'a>(
+    i: Input<'a>,
+    s: &'a Syntax<'a>
+) -> Result<(Input<'a>, &'a str), nom::Err<Input<'a>>> {
+    let bs = s.block_start.as_bytes()[0];
+
+    let mut last_brace = 0;
+    for (idx, c) in i.iter().enumerate() {
+        if *c == bs {
+            last_brace = idx;
+        }
+    }
+    Ok((Input(&i[last_brace..]), str::from_utf8(&i[..last_brace]).unwrap()))
+}
+
 named_args!(block_raw<'a>(s: &'a Syntax<'a>) <Input<'a>, Node<'a>>, do_parse!(
     pws1: opt!(tag!("-")) >>
     ws!(tag!("raw")) >>
     nws1: opt!(tag!("-")) >>
     call!(tag_block_end, s) >>
-    contents: take_until!("{% endraw %}") >>
+    contents: call!(take_raw_block, s) >>
     call!(tag_block_start, s) >>
     pws2: opt!(tag!("-")) >>
     ws!(tag!("endraw")) >>
     nws2: opt!(tag!("-")) >>
     ({
-        let str_contents = str::from_utf8(&contents).unwrap();
         (Node::Raw(WS(pws1.is_some(), nws1.is_some()),
-                   str_contents,
+                   contents,
                    WS(pws2.is_some(), nws2.is_some())))
     })
 ));

--- a/testing/templates/raw-complex.html
+++ b/testing/templates/raw-complex.html
@@ -1,5 +1,7 @@
 {% raw %}
 {% block name %}
-  <span>{{ name }}</span>
+{% for row in table %}
+<tr>{% for col in row %}<td>{{ col|escape }}</td>{% endfor %}</tr>
+{% endfor %}
 {% endblock %}
 {% endraw %}

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -301,12 +301,22 @@ fn test_empty() {
 }
 
 #[derive(Template)]
+#[template(source = "{% raw %}{% endraw %}", ext = "txt")]
+struct RawTemplateEmpty;
+
+#[test]
+fn test_raw_empty() {
+    let template = RawTemplateEmpty;
+    assert_eq!(template.render().unwrap(), "");
+}
+
+#[derive(Template)]
 #[template(path = "raw-simple.html")]
-struct RawTemplate;
+struct RawTemplateSimple;
 
 #[test]
 fn test_raw_simple() {
-    let template = RawTemplate;
+    let template = RawTemplateSimple;
     assert_eq!(template.render().unwrap(), "\n<span>{{ name }}</span>\n");
 }
 
@@ -316,11 +326,15 @@ struct RawTemplateComplex;
 
 #[test]
 fn test_raw_complex() {
+    let complex_block = "
+{% block name %}
+{% for row in table %}
+<tr>{% for col in row %}<td>{{ col|escape }}</td>{% endfor %}</tr>
+{% endfor %}
+{% endblock %}
+";
     let template = RawTemplateComplex;
-    assert_eq!(
-        template.render().unwrap(),
-        "\n{% block name %}\n  <span>{{ name }}</span>\n{% endblock %}\n"
-    );
+    assert_eq!(template.render().unwrap(), complex_block);
 }
 
 mod without_import_on_derive {


### PR DESCRIPTION
Hello,

I want to improve parsing of a `raw` block. 

There is some hard-code in here
https://github.com/djc/askama/blob/master/askama_derive/src/parser.rs#L846

Added `take_raw_block` function which will take content of a `raw` block.
The minus I see now in this PR that I could not came up with a failure case for this function to return `Err`.