### PR TITLE
[DNM] bump actix-web to 1.0

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -33,7 +33,7 @@ askama_escape = { version = "0.2.0", path = "../askama_escape" }
 askama_shared = { version = "0.8.0", path = "../askama_shared" }
 iron = { version = ">= 0.5, < 0.7", optional = true }
 rocket = { version = "0.4", optional = true }
-actix-web = { version = "0.7", optional = true }
+actix-web = { version = "1.0", optional = true }
 mime = { version = "0.3", optional = true }
 mime_guess = { version = "2.0.0-alpha", optional = true }
 gotham = { version = "0.3", optional = true }


### PR DESCRIPTION
`actix-0.8` does not work with `actix-web` 0.7, but requires `actix-web` 1.0. However, this is still in beta, and has a conflict on `ring` which is pulled in via `cookie` and `actix-http`.

Therefore, merge when:
- [x] actix-web 1.0 is released
- [x] https://github.com/alexcrichton/cookie-rs/issues/117 is resolved
   - [x] and the update propagates through to gotham (https://github.com/gotham-rs/gotham/issues/320)
   - [ ] and the update propagates through to rocket (https://github.com/SergioBenitez/Rocket/pull/1016)