### PR TITLE
I18n runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 
 script:
 - cargo test --all
+- cd askama_shared && cargo test --features full && cd ..
 - if [[ "${TRAVIS_RUST_VERSION}" == stable ]]; then
     cd testing && cargo test --features full && cargo fmt -- --check;
   fi

--- a/askama_shared/Cargo.toml
+++ b/askama_shared/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT/Apache-2.0"
 workspace = ".."
 edition = "2018"
 
+[features]
+full = ["with-i18n", "serde_json", "serde_yaml"]
+with-i18n = ["fluent-bundle", "lazy_static", "accept-language"]
+
 [dependencies]
 askama_escape = { version = "0.2.0", path = "../askama_escape" }
 humansize = "1.1.0"
@@ -18,3 +22,6 @@ serde_derive = "1.0"
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8", optional = true }
 toml = "0.5"
+fluent-bundle = { version = "0.6", optional = true }
+lazy_static = { version = "1.3", optional = true }
+accept-language = { version = "2.0", optional = true }

--- a/askama_shared/Cargo.toml
+++ b/askama_shared/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [features]
 full = ["with-i18n", "serde_json", "serde_yaml"]
-with-i18n = ["fluent-bundle", "lazy_static", "accept-language"]
+with-i18n = ["fluent-bundle", "fluent-locale", "lazy_static"]
 
 [dependencies]
 askama_escape = { version = "0.2.0", path = "../askama_escape" }
@@ -23,5 +23,5 @@ serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8", optional = true }
 toml = "0.5"
 fluent-bundle = { version = "0.6", optional = true }
+fluent-locale = { version = "0.4", optional = true }
 lazy_static = { version = "1.3", optional = true }
-accept-language = { version = "2.0", optional = true }

--- a/askama_shared/src/error.rs
+++ b/askama_shared/src/error.rs
@@ -36,6 +36,14 @@ pub enum Error {
     #[cfg(feature = "serde_yaml")]
     Yaml(::serde_yaml::Error),
 
+    /// internationalization error from fluent
+    #[cfg(feature = "with-i18n")]
+    I18n(::fluent_bundle::errors::FluentError),
+
+    /// missing locale error
+    #[cfg(feature = "with-i18n")]
+    NoTranslationsForMessage(String),
+
     /// This error needs to be non-exhaustive as
     /// the `Json` variants existence depends on
     /// a feature.
@@ -49,6 +57,12 @@ impl ErrorTrait for Error {
             Error::Fmt(ref err) => err.description(),
             #[cfg(feature = "serde_json")]
             Error::Json(ref err) => err.description(),
+            #[cfg(feature = "with-fluent")]
+            // fluent uses failure, don't want to bring all that in ;-;
+            Error::I18n(_) => "fluent i18n error",
+            #[cfg(feature = "with-fluent")]
+            // fluent uses failure, don't want to bring all that in ;-;
+            Error::NoTranslationsForMessage(_) => "missing translations for message",
             _ => "unknown error: __Nonexhaustive",
         }
     }
@@ -73,6 +87,12 @@ impl Display for Error {
             Error::Json(ref err) => write!(formatter, "json conversion error: {}", err),
             #[cfg(feature = "serde_yaml")]
             Error::Yaml(ref err) => write!(formatter, "yaml conversion error: {}", err),
+            #[cfg(feature = "with-fluent")]
+            Error::I18n(ref err) => write!(formatter, "fluent i18n error: {}", err),
+            #[cfg(feature = "with-fluent")]
+            Error::NoTranslationsForMessage(message) => {
+                write!("missing translations error for message `{:?}`", message)
+            }
             _ => write!(formatter, "unknown error: __Nonexhaustive"),
         }
     }

--- a/askama_shared/src/i18n_runtime.rs
+++ b/askama_shared/src/i18n_runtime.rs
@@ -1,0 +1,322 @@
+//! Code used in the implementation of `impl_localize!` and the `localize()` filter.
+//!
+//! Everything in this module should be considered an internal implementation detail; it is only public
+//! for use by the macro.
+//!
+//! Maintenance note: in general, the policy is to move as much i18n code as possible into here;
+//! whatever absolutely *must* be included in the generated code is done in askama_derive.
+
+use accept_language::parse as accept_language_parse;
+use fluent_bundle::{FluentBundle, FluentResource, FluentValue};
+use std::collections::HashMap;
+
+use super::{Error, Result};
+
+pub use lazy_static::lazy_static;
+
+/// An I18n argument value. Instantiated only by the `{ localize() }` filter.
+pub type I18nValue = fluent_bundle::FluentValue;
+
+/// A known locale. Instantiated only by the `impl_localize!` macro.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct Locale(pub &'static str);
+
+/// Sources; an array mapping Locales to fluent source strings. Instantiated only by the `impl_localize!` macro.
+pub type Sources = &'static [(Locale, &'static str)];
+
+/// Sources that have been parsed. Instantiated only by the `impl_localize!` macro.
+///
+/// This type is initialized in a lazy_static! in impl_localize!,
+/// because FluentBundle can only take FluentResources by reference;
+/// we have to store them somewhere to reference them.
+/// This can go away once https://github.com/projectfluent/fluent-rs/issues/103 lands.
+pub struct Resources(Vec<(Locale, FluentResource)>);
+
+impl Resources {
+    /// Parse a list of sources into a list of resources.
+    pub fn new(sources: Sources) -> Resources {
+        Resources(
+            sources
+                .iter()
+                .map(|(locale, source)| {
+                    (
+                        *locale,
+                        FluentResource::try_new(source.to_string())
+                            .expect("baked .ftl translation failed to parse"),
+                    )
+                })
+                .collect(),
+        )
+    }
+}
+
+/// StaticParser is a type that handles accessing the translations baked into
+/// the output executable / library easy. Instantiated only by the `impl_localize!` macro.
+pub struct StaticParser<'a> {
+    /// Bundles used for localization.
+    /// Maps long-form locales (e.g. "en_US", not just "en") to their respective bundles.
+    bundles: HashMap<Locale, FluentBundle<'a>>,
+
+    /// A listing of available locales.
+    /// Long-form locales map to themselves ("en_US" => [Locale("en_US")]);
+    /// Short-form locales map to all available long-form locales, in alphabetical order:
+    /// ("en" => [Locale("en_UK"), Locale("en_US")]).
+    locales: HashMap<&'static str, Vec<Locale>>,
+
+    /// The default locale chosen if no others can be determined.
+    default_locale: Locale,
+}
+
+impl<'a> StaticParser<'a> {
+    /// Create a StaticParser.
+    pub fn new(resources: &'a Resources, default_locale: Locale) -> StaticParser<'a> {
+        assert!(
+            resources
+                .0
+                .iter()
+                .find(|(locale, _)| *locale == default_locale)
+                .is_some(),
+            "default locale not available!"
+        );
+
+        let mut bundles = HashMap::new();
+        let mut locales = HashMap::new();
+        for (locale, resource) in resources.0.iter() {
+            // confusingly, this value is used by fluent for number and date formatting only.
+            // we have to implement looking up missing messages in other bundles ourselves.
+            let fallback_chain = &[locale.0];
+
+            let mut bundle = FluentBundle::new(fallback_chain);
+
+            bundle
+                .add_resource(resource)
+                .expect("failed to add resource");
+            bundles.insert(*locale, bundle);
+            locales.insert(locale.0, vec![*locale]);
+
+            let short = &locale.0[..2];
+            let shorts = locales.entry(short).or_insert_with(|| vec![]);
+            shorts.push(*locale);
+            // ensure determinism in fallback order
+            shorts.sort();
+        }
+
+        StaticParser {
+            bundles,
+            locales,
+            default_locale,
+        }
+    }
+
+    /// Creates a chain of locales to use for message lookups.
+    /// * `user_locales`: a list of locales allowed by the user,
+    ///   in descending order of preference.
+    ///    - May be empty.
+    ///    - May be short-form locales (e.g. "en")
+    /// * `accept_language`: an `Accept-Language` header, if present.
+    pub fn create_locale_chain(
+        &self,
+        user_locales: &[&str],
+        accept_language: Option<&str>,
+    ) -> Vec<Locale> {
+        let mut chain = vec![];
+
+        // when adding a locale "en_AU", also check its short form "en",
+        // and also add all locales that that short form maps to.
+        // this ensures that a locale chain like "es-AR", "en-US" will
+        // pull messages from "es-MX" before going to english.
+        //
+        // note: this has the side effect of discarding some ordering information.
+        //
+        // TODO: discuss whether this is a reasonable approach.
+        let mut add = |locale_code: &str| {
+            let mut codes = &[locale_code, &locale_code[..2]][..];
+            if locale_code.len() == 2 {
+                codes = &codes[..1]
+            }
+
+            for code in codes {
+                if let Some(locales) = self.locales.get(code) {
+                    for locale in locales {
+                        if !chain.contains(locale) {
+                            chain.push(*locale);
+                        }
+                    }
+                }
+            }
+        };
+        for locale_code in user_locales {
+            add(locale_code);
+        }
+        if let Some(accept_language) = accept_language {
+            for locale_code in &accept_language_parse(accept_language) {
+                add(locale_code);
+            }
+        }
+
+        if !chain.contains(&self.default_locale) {
+            chain.push(self.default_locale);
+        }
+
+        chain
+    }
+
+    /// Localize a message.
+    /// * `locale_chain`: a list of locales, in descending order of preference
+    /// * `message`: a message ID
+    /// * `args`: a slice of arguments to pass to Fluent.
+    pub fn localize(
+        &self,
+        locale_chain: &[Locale],
+        message: &str,
+        args: &[(&str, &FluentValue)],
+    ) -> Result<String> {
+        let args = if args.len() == 0 {
+            None
+        } else {
+            Some(args.into_iter().map(|(k, v)| (*k, (*v).clone())).collect())
+        };
+        let args = args.as_ref();
+
+        for locale in locale_chain {
+            let bundle = self.bundles.get(locale);
+            let bundle = if let Some(bundle) = bundle {
+                bundle
+            } else {
+                // TODO warn?
+                continue;
+            };
+            // this API is weirdly awful;
+            // format returns Option<(String, Vec<FluentError>)>
+            // which we have to cope with
+            let result = bundle.format(message, args);
+
+            if let Some((result, errs)) = result {
+                if errs.len() == 0 {
+                    return Ok(result);
+                } else {
+                    continue;
+
+                    // TODO: fluent degrades gracefully; maybe just warn here?
+                    // Err(Error::I18n(errs.pop().unwrap()))
+                }
+            }
+        }
+        // nowhere to fall back to
+        Err(Error::NoTranslationsForMessage(format!(
+            "no translations for message {} in locale chain {:?}",
+            message, locale_chain
+        )))
+    }
+
+    pub fn has_message(&self, locale_chain: &[Locale], message: &str) -> bool {
+        locale_chain
+            .iter()
+            .flat_map(|locale| self.bundles.get(locale))
+            .any(|bundle| bundle.has_message(message))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCES: Sources = &[
+        (
+            Locale("en_US"),
+            r#"
+greeting = Hello, { $name }! You are { $hours } hours old.
+goodbye = Goodbye.
+"#,
+        ),
+        (
+            Locale("en_AU"),
+            r#"
+greeting = G'day, { $name }! You are { $hours } hours old.
+goodbye = Hooroo.
+"#,
+        ),
+        (
+            Locale("es_MX"),
+            r#"
+greeting = ¡Hola, { $name }! Tienes { $hours } horas.
+goodbye = Adiós.
+"#,
+        ),
+        (
+            Locale("de_DE"),
+            "greeting = Hallo { $name }! Du bist { $hours } Stunden alt.",
+        ),
+    ];
+
+    #[test]
+    fn basic() -> Result<()> {
+        let resources = Resources::new(SOURCES);
+        let bundles = StaticParser::new(&resources, Locale("en_US"));
+        let name = FluentValue::from("Jamie");
+        let hours = FluentValue::from(190321.31);
+        let args = &[("name", &name), ("hours", &hours)][..];
+
+        assert_eq!(
+            bundles.localize(&[Locale("en_US")], "greeting", args)?,
+            "Hello, Jamie! You are 190321.31 hours old."
+        );
+        assert_eq!(
+            bundles.localize(&[Locale("es_MX")], "greeting", args)?,
+            "¡Hola, Jamie! Tienes 190321.31 horas."
+        );
+        assert_eq!(
+            bundles.localize(&[Locale("de_DE")], "greeting", args)?,
+            "Hallo Jamie! Du bist 190321.31 Stunden alt."
+        );
+
+        // missing messages should fall back to first available
+        assert_eq!(
+            bundles.localize(
+                &[Locale("de_DE"), Locale("es_MX"), Locale("en_US")],
+                "goodbye",
+                &[]
+            )?,
+            "Adiós."
+        );
+
+        if let Ok(_) = bundles.localize(&[Locale("en_US")], "bananas", &[]) {
+            panic!("Should return Err on missing message");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn create_locale_chain() {
+        let resources = Resources::new(SOURCES);
+        let bundles = StaticParser::new(&resources, Locale("en_US"));
+
+        // accept-language parser works + short-code lookup works
+        assert_eq!(
+            bundles.create_locale_chain(&[], Some("en_US, es_MX; q=0.5")),
+            &[Locale("en_US"), Locale("en_AU"), Locale("es_MX")]
+        );
+
+        // first choice has precedence
+        assert_eq!(
+            bundles.create_locale_chain(&["es_MX"], Some("en_US; q=0.5")),
+            &[Locale("es_MX"), Locale("en_US"), Locale("en_AU")]
+        );
+
+        // short codes work
+        assert_eq!(
+            bundles.create_locale_chain(&[], Some("en")),
+            &[Locale("en_AU"), Locale("en_US")]
+        );
+
+        // default works
+        assert_eq!(bundles.create_locale_chain(&[], None), &[Locale("en_US")]);
+
+        // missing languages fall through to default
+        assert_eq!(
+            bundles.create_locale_chain(&["zh_HK"], Some("xy_ZW")),
+            &[Locale("en_US")]
+        );
+    }
+}

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -2,6 +2,11 @@
 #[macro_use]
 extern crate serde_derive;
 
+#[cfg(feature = "with-i18n")]
+extern crate accept_language;
+#[cfg(feature = "with-i18n")]
+extern crate fluent_bundle;
+
 use toml;
 
 use std::collections::HashSet;
@@ -18,6 +23,9 @@ use std::collections::BTreeMap;
 
 pub mod filters;
 pub mod helpers;
+
+#[cfg(feature = "with-i18n")]
+pub mod i18n_runtime;
 
 #[derive(Debug)]
 pub struct Config<'a> {
@@ -404,7 +412,10 @@ mod tests {
             vec![
                 (str_set(&["js"]), "::askama::Js".into()),
                 (str_set(&["html", "htm", "xml"]), "::askama::Html".into()),
-                (str_set(&["md", "none", "txt", "yml", ""]), "::askama::Text".into()),
+                (
+                    str_set(&["md", "none", "txt", "yml", ""]),
+                    "::askama::Text".into()
+                ),
                 (str_set(&["j2", "jinja", "jinja2"]), "::askama::Html".into()),
             ]
         );

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -3,9 +3,9 @@
 extern crate serde_derive;
 
 #[cfg(feature = "with-i18n")]
-extern crate accept_language;
-#[cfg(feature = "with-i18n")]
 extern crate fluent_bundle;
+#[cfg(feature = "with-i18n")]
+extern crate fluent_locale;
 
 use toml;
 


### PR DESCRIPTION
This PR adds an I18n runtime to `askama_shared`. There's no codegen yet, though.

This is a little wacky because we're reimplementing some features provided by fluent. (See discussion [here](https://github.com/projectfluent/fluent-rs/issues/64#issuecomment-489471933)).

Open questions:
- Should we add `log` or `slog` to register errors? Fluent is designed to degrade gracefully when errors are present.
- Currently, fluent requires allocating a `HashMap` of arguments for every call (that takes arguments). Should we instead add a `thread_local!` `HashMap` and transparently re-use it for each call? In my benchmarks this takes ~250ns off of every call to `localize` (which takes ~500ns on average). However, it's a little weird for Rust.
- I do a little bit of wacky pre-processing when choosing a locale fallback chain for a user, not sure if it's the right design. See my TODO: discuss comment in the code.