### PR TITLE
Add support for static function calls

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -880,6 +880,9 @@ impl<'a> Generator<'a> {
             Expr::MethodCall(ref obj, method, ref args) => {
                 self.visit_method_call(buf, obj, method, args)
             }
+            Expr::FnCall(ref path, ref args) => {
+                self.visit_fn_call(buf, path, args)
+            }
             Expr::RustMacro(name, args) => self.visit_rust_macro(buf, name, args),
         }
     }
@@ -1030,6 +1033,24 @@ impl<'a> Generator<'a> {
         buf.write("[");
         self.visit_expr(buf, key);
         buf.write("]");
+        DisplayWrap::Unwrapped
+    }
+
+    fn visit_fn_call(
+        &mut self,
+        buf: &mut Buffer,
+        path: &Expr,
+        args: &[Expr],
+    ) -> DisplayWrap {
+        if let Expr::Var("self") = path {
+            buf.write("self");
+        } else {
+            self.visit_expr(buf, path);
+        }
+
+        buf.write("(");
+        self._visit_args(buf, args);
+        buf.write(")");
         DisplayWrap::Unwrapped
     }
 

--- a/testing/tests/functions.rs
+++ b/testing/tests/functions.rs
@@ -1,0 +1,46 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(source = "{{ self::simple_test_fn() }}", ext = "txt")]
+struct FnTemplate;
+
+fn simple_test_fn() -> &'static str {
+    "foo"
+}
+
+#[test]
+fn test_fn() {
+    let t = FnTemplate;
+    assert_eq!(t.render().unwrap(), "foo");
+}
+
+
+#[derive(Template)]
+#[template(source = "{{ self::arg_test_fn(arg) }}", ext = "txt")]
+struct FnArgsTemplate{
+    arg: &'static str
+}
+
+fn arg_test_fn(s: &'static str) -> String {
+    format!("{}!", s)
+}
+
+#[test]
+fn test_fn_args() {
+    let t = FnArgsTemplate { arg: "foo" };
+    assert_eq!(t.render().unwrap(), "foo!");
+}
+
+
+#[derive(Template)]
+#[template(source = "{% if self::if_test_fn() %}foo{% endif %}", ext = "txt")]
+struct FnIfTemplate;
+
+fn if_test_fn() -> bool { true }
+
+#[test]
+fn test_fn_if() {
+    let t = FnIfTemplate;
+    assert_eq!(t.render().unwrap(), "foo");
+}
+


### PR DESCRIPTION
This allows static functions to be called from templates using an expression like `self::static_fn(arg)`. This fixes #196.

I haven't tested this outside of the 3 test cases I wrote, so maybe a little more testing should be done before merging this.