### PR TITLE
Add support for dereference operator

### DIFF
--- a/askama_derive/src/parser.rs
+++ b/askama_derive/src/parser.rs
@@ -472,7 +472,7 @@ named!(expr_filtered<Input, Expr>, do_parse!(
 ));
 
 named!(expr_unary<Input, Expr>, do_parse!(
-    op: opt!(alt!(tag!("!") | tag!("-"))) >>
+    op: opt!(alt!(tag!("!") | tag!("-") | tag!("*"))) >>
     expr: expr_filtered >>
     (match op {
         Some(op) => Expr::Unary(str::from_utf8(op.0).unwrap(), Box::new(expr)),


### PR DESCRIPTION
The use case I had for this, was to be able to do something like the following (the same applies to #265):

```
{% macro foo(b) %}
  {% if *b %}
    X
  {% else %}
    Y
  {% endif %}
{% endmacro %}

{% call foo(true) %}
{% call foo(false) %}
```

Which seemed necessary, because of arguments in calls being referenced [here](https://github.com/djc/askama/blob/66274b7c8ef2f47fe479013b9d408ac21a36472d/askama_derive/src/generator.rs#L605)