### PR TITLE
Support function calls

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1030,7 +1030,10 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
             }
 
             let scoped = match *arg {
-                Expr::Filter(_, _) | Expr::MethodCall(_, _, _) => true,
+                Expr::Filter(_, _)
+                | Expr::MethodCall(_, _, _)
+                | Expr::VarCall(_, _)
+                | Expr::PathCall(_, _) => true,
                 _ => false,
             };
 
@@ -1169,13 +1172,8 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
             }
             buf.write(part);
         }
-        buf.write("(");
-        for (i, arg) in args.iter().enumerate() {
-            if i > 0 {
-                buf.write(",");
-            }
-            self.visit_expr(buf, arg);
-        }
+        buf.write("(&");
+        self._visit_args(buf, args);
         buf.write(")");
         DisplayWrap::Unwrapped
     }
@@ -1198,13 +1196,8 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
             buf.write("self.");
             buf.write(s);
         }
-        buf.write(")(");
-        for (i, arg) in args.iter().enumerate() {
-            if i > 0 {
-                buf.write(",");
-            }
-            self.visit_expr(buf, arg);
-        }
+        buf.write(")(&");
+        self._visit_args(buf, args);
         buf.write(")");
         DisplayWrap::Unwrapped
     }

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -276,6 +276,7 @@ fn test_func_ref_call() {
     assert_eq!(t.render().unwrap(), "Hello, world(123, 4)!");
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn world2(s: &str, v: &u8) -> String {
     format!("world{}{}", v, s)
 }
@@ -294,6 +295,7 @@ fn test_path_func_call() {
 struct FunctionTemplate;
 
 impl FunctionTemplate {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     fn world3(&self, s: &str, v: &u8) -> String {
         format!("world{}{}", s, v)
     }

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -265,7 +265,7 @@ fn test_slice_literal() {
 #[derive(Template)]
 #[template(source = "Hello, {{ world(\"123\", 4) }}!", ext = "txt")]
 struct FunctionRefTemplate {
-    world: fn(s: &str, v: u8) -> String,
+    world: fn(s: &str, v: &u8) -> String,
 }
 
 #[test]
@@ -276,7 +276,7 @@ fn test_func_ref_call() {
     assert_eq!(t.render().unwrap(), "Hello, world(123, 4)!");
 }
 
-fn world2(s: &str, v: u8) -> String {
+fn world2(s: &str, v: &u8) -> String {
     format!("world{}{}", v, s)
 }
 
@@ -294,7 +294,7 @@ fn test_path_func_call() {
 struct FunctionTemplate;
 
 impl FunctionTemplate {
-    fn world3(&self, s: &str, v: u8) -> String {
+    fn world3(&self, s: &str, v: &u8) -> String {
         format!("world{}{}", s, v)
     }
 }

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -263,6 +263,43 @@ fn test_slice_literal() {
 }
 
 #[derive(Template)]
+#[template(source = "Hello, {{ world(\"123\", 4) }}!", ext = "txt")]
+struct FunctionRefTemplate {
+    world: fn(s: &str, v: u8) -> String,
+}
+
+#[test]
+fn test_func_ref_call() {
+    let t = FunctionRefTemplate {
+        world: |s, r| format!("world({}, {})", s, r),
+    };
+    assert_eq!(t.render().unwrap(), "Hello, world(123, 4)!");
+}
+
+fn world2(s: &str, v: u8) -> String {
+    format!("world{}{}", v, s)
+}
+
+#[derive(Template)]
+#[template(source = "Hello, {{ self::world2(\"123\", 4) }}!", ext = "txt")]
+struct PathFunctionTemplate;
+
+#[test]
+fn test_path_func_call() {
+    assert_eq!(PathFunctionTemplate.render().unwrap(), "Hello, world4123!");
+}
+
+#[derive(Template)]
+#[template(source = "Hello, {{ Self::world3(self, \"123\", 4) }}!", ext = "txt")]
+struct FunctionTemplate;
+
+impl FunctionTemplate {
+    fn world3(&self, s: &str, v: u8) -> String {
+        format!("world{}{}", s, v)
+    }
+}
+
+#[derive(Template)]
 #[template(source = "  {# foo -#} ", ext = "txt")]
 struct CommentTemplate {}
 


### PR DESCRIPTION
This allows function calls in templates. There are multiple ways a function could be called: static callables (e.g. static functions), methods on template (in an impl block) and function pointer calls (template has an attribute of type e.g. FnOnce(args) -> String).

I tried to be consistent with the ways things are right now: i.e. {{ var }} refers to an attribute of the template, and path::CONST refers to a constant declared in the path module.

Case 1 : `callable` is an attribute of `Template`.

```rust
#[derive(Template)]
#[template(source = "{{ callable(123) }}", ext = "txt")]
struct Template {
    callable: fn(u32) -> String,
}
```

Case 2: `callable` is in the outer context (e.g. static function)

```rust
fn callable(val: u32) -> String {
    format!("{}", val)
}

#[derive(Template)]
#[template(source = "{{ self::callable(123) }}", ext = "txt")]
struct Template;
```

Case 3: `callable` is a method:
Actually, methods are just static functions that take `&self` as an argument.

```rust
#[derive(Template)]
#[template(source = "{{ Self::callable(self, 123) }}", ext = "txt")]
struct Template;

impl Template {
    fn callable(&self, val: u32) -> String {
        format!("{}", val)
    }
}
```

This last case might seem weird at first, but it actually keeps things consistent in the mind of the programmer, i.e. {{ var }} refers to an attribute of the template and {{ path::var }} refers to something else.

I also need to update the documentation to explain this simply.

Fixes #285, fixes #196

EDIT: Removed reference to an issue that this does not actueally address.