### PR TITLE
fix: make filesizeformat work with all types that implement humansize::FileSize

### DIFF
--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -125,7 +125,7 @@ where
 
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
-pub fn filesizeformat(b: &dyn humansize::FileSize) -> Result<String> {
+pub fn filesizeformat<B: FileSize>(b: B) -> Result<String> {
     b.file_size(file_size_opts::DECIMAL)
         .map_err(|_| Fmt(fmt::Error))
 }

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -22,6 +22,8 @@ use crate::error::Error::Fmt;
 use askama_escape::{Escaper, MarkupDisplay};
 #[cfg(feature = "humansize")]
 use humansize::{file_size_opts, FileSize};
+#[cfg(feature = "humansize")]
+use std::borrow::Borrow;
 #[cfg(feature = "num_traits")]
 use num_traits::{cast::NumCast, Signed};
 #[cfg(feature = "percent-encoding")]
@@ -125,8 +127,8 @@ where
 
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
-pub fn filesizeformat<R: AsRef<B>, B: FileSize>(b: R) -> Result<String> {
-    b.as_ref()
+pub fn filesizeformat<R: Borrow<B>, B: FileSize>(b: R) -> Result<String> {
+    b.borrow()
         .file_size(file_size_opts::DECIMAL)
         .map_err(|_| Fmt(fmt::Error))
 }

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -127,9 +127,8 @@ where
 
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
-pub fn filesizeformat<R: Borrow<B>, B: FileSize>(b: R) -> Result<String> {
-    b.borrow()
-        .file_size(file_size_opts::DECIMAL)
+pub fn filesizeformat<B: FileSize>(b: B) -> Result<String> {
+    b.file_size(file_size_opts::DECIMAL)
         .map_err(|_| Fmt(fmt::Error))
 }
 
@@ -340,10 +339,10 @@ mod tests {
     #[test]
     fn test_filesizeformat() {
         assert_eq!(filesizeformat(0).unwrap(), "0 B");
-        assert_eq!(filesizeformat(999).unwrap(), "999 B");
-        assert_eq!(filesizeformat(1000).unwrap(), "1 KB");
+        assert_eq!(filesizeformat(999u64).unwrap(), "999 B");
+        assert_eq!(filesizeformat(1000i32).unwrap(), "1 KB");
         assert_eq!(filesizeformat(1023).unwrap(), "1.02 KB");
-        assert_eq!(filesizeformat(1024).unwrap(), "1.02 KB");
+        assert_eq!(filesizeformat(1024usize).unwrap(), "1.02 KB");
     }
 
     #[cfg(feature = "percent-encoding")]

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -125,8 +125,9 @@ where
 
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
-pub fn filesizeformat<B: FileSize>(b: B) -> Result<String> {
-    b.file_size(file_size_opts::DECIMAL)
+pub fn filesizeformat<B: FileSize>(b: &dyn AsRef<B>) -> Result<String> {
+    b.as_ref()
+        .file_size(file_size_opts::DECIMAL)
         .map_err(|_| Fmt(fmt::Error))
 }
 

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -125,7 +125,7 @@ where
 
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
-pub fn filesizeformat<B: FileSize>(b: &dyn AsRef<B>) -> Result<String> {
+pub fn filesizeformat<R: AsRef<B>, B: FileSize>(b: R) -> Result<String> {
     b.as_ref()
         .file_size(file_size_opts::DECIMAL)
         .map_err(|_| Fmt(fmt::Error))

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -125,7 +125,7 @@ where
 
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
-pub fn filesizeformat(b: usize) -> Result<String> {
+pub fn filesizeformat(b: &dyn humansize::FileSize) -> Result<String> {
     b.file_size(file_size_opts::DECIMAL)
         .map_err(|_| Fmt(fmt::Error))
 }

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -22,12 +22,12 @@ use crate::error::Error::Fmt;
 use askama_escape::{Escaper, MarkupDisplay};
 #[cfg(feature = "humansize")]
 use humansize::{file_size_opts, FileSize};
-#[cfg(feature = "humansize")]
-use std::borrow::Borrow;
 #[cfg(feature = "num_traits")]
 use num_traits::{cast::NumCast, Signed};
 #[cfg(feature = "percent-encoding")]
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+#[cfg(feature = "humansize")]
+use std::borrow::Borrow;
 
 use super::Result;
 

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -127,7 +127,7 @@ where
 
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
-pub fn filesizeformat<B: FileSize>(b: B) -> Result<String> {
+pub fn filesizeformat<B: FileSize>(b: &B) -> Result<String> {
     b.file_size(file_size_opts::DECIMAL)
         .map_err(|_| Fmt(fmt::Error))
 }
@@ -338,11 +338,11 @@ mod tests {
     #[cfg(feature = "humansize")]
     #[test]
     fn test_filesizeformat() {
-        assert_eq!(filesizeformat(0).unwrap(), "0 B");
-        assert_eq!(filesizeformat(999u64).unwrap(), "999 B");
-        assert_eq!(filesizeformat(1000i32).unwrap(), "1 KB");
-        assert_eq!(filesizeformat(1023).unwrap(), "1.02 KB");
-        assert_eq!(filesizeformat(1024usize).unwrap(), "1.02 KB");
+        assert_eq!(filesizeformat(&0).unwrap(), "0 B");
+        assert_eq!(filesizeformat(&999u64).unwrap(), "999 B");
+        assert_eq!(filesizeformat(&1000i32).unwrap(), "1 KB");
+        assert_eq!(filesizeformat(&1023).unwrap(), "1.02 KB");
+        assert_eq!(filesizeformat(&1024usize).unwrap(), "1.02 KB");
     }
 
     #[cfg(feature = "percent-encoding")]

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -26,8 +26,6 @@ use humansize::{file_size_opts, FileSize};
 use num_traits::{cast::NumCast, Signed};
 #[cfg(feature = "percent-encoding")]
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
-#[cfg(feature = "humansize")]
-use std::borrow::Borrow;
 
 use super::Result;
 


### PR DESCRIPTION
~~I have enabled dynamic dispatch on the filesizeformat filter's parameter as to allow for numbers other than usize to work~~

As per my commit 1:
dynamic dyspatch would not work since file_size takes a generic.
Instead we use a generic function with type B being any type that implements FileSize.