### PR TITLE
Add support for `io::Write` render method (i.e. `render_into_bytes` and `render_bytes`)

### DIFF
--- a/askama_shared/src/error.rs
+++ b/askama_shared/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// formatting error
     Fmt(fmt::Error),
 
+    /// IO write error (only if used with `render_into_bytes`)
+    Io(std::io::Error),
+
     /// json conversion error
     #[cfg(feature = "serde_json")]
     Json(::serde_json::Error),
@@ -41,6 +44,7 @@ impl std::error::Error for Error {
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::Fmt(ref err) => err.source(),
+            Error::Io(ref err) => err.source(),
             #[cfg(feature = "serde_json")]
             Error::Json(ref err) => err.source(),
             #[cfg(feature = "serde_yaml")]
@@ -53,6 +57,7 @@ impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Error::Fmt(ref err) => write!(formatter, "formatting error: {}", err),
+            Error::Io(ref err) => write!(formatter, "formatting error: {}", err),
             #[cfg(feature = "serde_json")]
             Error::Json(ref err) => write!(formatter, "json conversion error: {}", err),
             #[cfg(feature = "serde_yaml")]

--- a/askama_shared/src/io/mod.rs
+++ b/askama_shared/src/io/mod.rs
@@ -18,6 +18,9 @@ impl<W: std::io::Write> std::fmt::Write for WriteIoToFmt<W> {
         if self.error.is_some() {
             return Err(std::fmt::Error);
         }
+        if s.is_empty() {
+            return Ok(());
+        }
         match self.write.write_all(s.as_bytes()) {
             Ok(()) => Ok(()),
             Err(error) => {

--- a/askama_shared/src/io/mod.rs
+++ b/askama_shared/src/io/mod.rs
@@ -1,0 +1,29 @@
+pub struct WriteIoToFmt<W: std::io::Write> {
+    write: W,
+    error: Option<std::io::Error>,
+}
+
+impl<W: std::io::Write> WriteIoToFmt<W> {
+    pub fn new(write: W) -> Self {
+        Self { write, error: None }
+    }
+
+    pub fn error(self) -> Option<std::io::Error> {
+        self.error
+    }
+}
+
+impl<W: std::io::Write> std::fmt::Write for WriteIoToFmt<W> {
+    fn write_str(&mut self, s: &str) -> Result<(), std::fmt::Error> {
+        if self.error.is_some() {
+            return Err(std::fmt::Error);
+        }
+        match self.write.write_all(s.as_bytes()) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.error = Some(error);
+                Err(std::fmt::Error)
+            }
+        }
+    }
+}

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -20,6 +20,7 @@ pub mod helpers;
 pub mod heritage;
 #[doc(hidden)]
 pub mod input;
+pub mod io;
 #[doc(hidden)]
 pub mod parser;
 

--- a/testing/benches/all.rs
+++ b/testing/benches/all.rs
@@ -8,11 +8,21 @@ criterion_main!(benches);
 criterion_group!(benches, functions);
 
 fn functions(c: &mut Criterion) {
-    c.bench_function("Big table", |b| big_table(b, 100));
-    c.bench_function("Teams", teams);
+    c.bench_function("Big table (string)", |b| big_table_string(b, 100));
+    c.bench_function("Big table (bytes)", |b| big_table_bytes(b, 100));
+    c.bench_function("Teams (string)", teams_string);
+    c.bench_function("Teams (bytes)", teams_bytes);
 }
 
-fn big_table(b: &mut criterion::Bencher, size: usize) {
+fn big_table_string(b: &mut criterion::Bencher, size: usize) {
+    let ctx = big_table_build(size);
+    b.iter(|| ctx.render().unwrap());
+}
+fn big_table_bytes(b: &mut criterion::Bencher, size: usize) {
+    let ctx = big_table_build(size);
+    b.iter(|| ctx.render_bytes().unwrap());
+}
+fn big_table_build(size: usize) -> BigTable {
     let mut table = Vec::with_capacity(size);
     for _ in 0..size {
         let mut inner = Vec::with_capacity(size);
@@ -21,8 +31,7 @@ fn big_table(b: &mut criterion::Bencher, size: usize) {
         }
         table.push(inner);
     }
-    let ctx = BigTable { table };
-    b.iter(|| ctx.render().unwrap());
+    BigTable { table }
 }
 
 #[derive(Template)]
@@ -31,8 +40,16 @@ struct BigTable {
     table: Vec<Vec<usize>>,
 }
 
-fn teams(b: &mut criterion::Bencher) {
-    let teams = Teams {
+fn teams_string(b: &mut criterion::Bencher) {
+    let teams = teams_build();
+    b.iter(|| teams.render().unwrap());
+}
+fn teams_bytes(b: &mut criterion::Bencher) {
+    let teams = teams_build();
+    b.iter(|| teams.render_bytes().unwrap());
+}
+fn teams_build() -> Teams {
+    Teams {
         year: 2015,
         teams: vec![
             Team {
@@ -52,8 +69,7 @@ fn teams(b: &mut criterion::Bencher) {
                 score: 12,
             },
         ],
-    };
-    b.iter(|| teams.render().unwrap());
+    }
 }
 
 #[derive(Template)]

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -27,6 +27,14 @@ fn test_variables() {
          in vars too: Iñtërnâtiônàlizætiøn"
     );
     assert_eq!(
+        s.render_bytes().unwrap().as_slice(),
+        "\nhello world, foo\n\
+         with number: 42\n\
+         Iñtërnâtiônàlizætiøn is important\n\
+         in vars too: Iñtërnâtiônàlizætiøn"
+            .as_bytes()
+    );
+    assert_eq!(
         <VariablesTemplate as SizedTemplate>::extension(),
         Some("html")
     );


### PR DESCRIPTION
As promissed in https://github.com/djc/askama/issues/163, here is a pul request that does the following:
* adds a new `render_into_bytes` that takes a `io::Write` instance, and adapts it to `fmt::Write` and calls the plain `render_into` method;
* adds a new `render_bytes` similar to `render` that returns a `Vec<u8>` instead of a `String`;

The two changes above are trivial, however there is a backward compatibility issue: in order to properly return an `io::Error`, I had to add the `Io` enum variant to `Error`, therefore this will fail in cases where the user hasn't included a `_` pattern in the match.

Additionally, the bulk of the pull request, in order to aid tests, I've done the following:
* created an `assert_render!` macro that should replace the usage of `assert_eq!(t.render().unwrap(), "expected")` with just `assert_render!(t, "expected")`;  the macro calls both `render()` and `render_bytes()` to check that the output is correctly generated via both implementations;
* I've updated all the test cases to use the `assert_render!` macro described above;  (I've left the integration tests alone;)
* I've updated the benchmarking code to include the `render_bytes` function;  (I've renamed the previous function with the `_string` suffix, and added a new one with `_bytes` suffix to be more clear;)

Regarding benchmarks, it appears that the `render_bytes` (i.e. `Vec<u8>`) method is somewhat slower than the `render` (i.e. `String`) variant.

BTW, the `assert_render!` macro could be used in the future to make sure that for example no write methods are called with an empty string as I've reported in another issue.
