### PR TITLE
Update `EscapeWriter` HTML implementation to not output empty strings

### DIFF
--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -129,7 +129,11 @@ impl Escaper for Html {
                 }
             }
         }
-        fmt.write_str(unsafe { str::from_utf8_unchecked(&bytes[start..]) })
+        if start < bytes.len() {
+            fmt.write_str(unsafe { str::from_utf8_unchecked(&bytes[start..]) })
+        } else {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
As discussed in #318 