### PR TITLE
Add support for `{% stripspace %}`, `{% space %}` and friends

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -199,6 +199,21 @@
 //! includes only whitespace, whitespace suppression on either side will
 //! completely suppress that literal content.
 //!
+//! It is also possible to make all statements behave as if they were defined
+//! with `{%- ... -%}` by enclosing them in a `stripspace` block.
+//!
+//! For example the next snippet is equivalent with the previous one:
+//!
+//! ```text
+//! {% stripspace %}
+//!   {% if foo %}
+//!     {{ bar }}
+//!   {% else if %}
+//!     nothing
+//!   {% endif %}
+//! {% endstripspace %}
+//! ```
+//!
 //! ## Template inheritance
 //!
 //! Template inheritance allows you to build a base template with common

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -214,6 +214,9 @@
 //! {% endstripspace %}
 //! ```
 //!
+//! Within the `stripspace` blocks (and not only) one could use `{% space %}`,
+//! `{% tab %}` and `{% newline %}` to force spaces before and after other blocks.
+//!
 //! ## Template inheritance
 //!
 //! Template inheritance allows you to build a base template with common

--- a/testing/templates/stripspace.html
+++ b/testing/templates/stripspace.html
@@ -1,0 +1,23 @@
+[
+{% stripspace %}
+
+  1
+  2
+
+  {% if true %}
+
+    3
+    4
+
+  {% else %}
+
+    5
+    6
+
+  {% endif %}
+
+  7
+  8
+
+{% endstripspace %}
+]

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -412,3 +412,13 @@ fn test_strip_space() {
     let template = StripSpace;
     assert_eq!(template.render().unwrap(), "[\n1\n  23\n    47\n  8\n]");
 }
+
+#[derive(askama::Template)]
+#[template(source = " {%- space -%} {% tab %} {% newline -%}", ext = "txt")]
+struct InsertSpace;
+
+#[test]
+fn test_insert_space() {
+    let template = InsertSpace;
+    assert_eq!(template.render().unwrap(), " \t \n");
+}

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -402,3 +402,13 @@ fn test_define_string_var() {
     let template = DefineStringVar;
     assert_eq!(template.render().unwrap(), "");
 }
+
+#[derive(askama::Template)]
+#[template(path = "stripspace.html")]
+struct StripSpace;
+
+#[test]
+fn test_strip_space() {
+    let template = StripSpace;
+    assert_eq!(template.render().unwrap(), "[\n1\n  23\n    47\n  8\n]");
+}


### PR DESCRIPTION
As discussed in #317 I'm submitting my two patches that introduce both `{% stripspace %}` and `{% space %}` blocks.

As argumented in that issue, I believe that `{% stripspace %}` is not complete without `{% space %}` and friends for two main reasons:
* there are corner cases that can't be efficiently covered by `{{ " " }}`;
* it provides compatibility with Go's `quicktemplate`;
