### PR TITLE
Add support for more whitespace positions within expressions

### DIFF
--- a/testing/templates/allow-whitespaces.html
+++ b/testing/templates/allow-whitespaces.html
@@ -1,0 +1,63 @@
+
+{{ tuple.0 }}
+{{ tuple .1 }}
+{{ tuple. 2 }}
+{{ tuple . 3 }}
+{% let ( t0 , t1 , t2 , t3 , ) = tuple %}
+
+{{ string }}
+{{ string.len( ) }}
+{{ string . len () }}
+{{ string . len () }}
+{{ string. len () }}
+{{ string . len ( ) }}
+
+{{ nested_1 . nested_2 . array [0] }}
+{{ nested_1 .nested_2. array [ 1 ] }}
+{{ nested_1 .nested_2. hash [ "key" ] }}
+
+{% let array = nested_1.nested_2.array %}
+{#
+{% let array = nested_1.nested_2.array %}
+{% let array = nested_1 . nested_2 . array %}
+#}
+{#
+{% let hash = &nested_1.nested_2.hash %}
+#}
+
+{{ array| json }}
+{{ array[..]| json }}{{ array [ .. ]| json }}
+{{ array[1..2]| json }}{{ array [ 1 .. 2 ]| json }}
+{{ array[1..=2]| json }}{{ array [ 1 ..= 2 ]| json }}
+{{ array[(0+1)..(3-2)]| json }}{{ array [ ( 0 + 1 ) .. ( 3 - 2 ) ]| json }}
+
+{{-1}}{{ -1 }}{{ - 1 }}
+{{1+2}}{{ 1+2 }}{{ 1 +2 }}{{ 1+ 2 }} {{ 1 + 2 }}
+{{1*2}}{{ 1*2 }}{{ 1 *2 }}{{ 1* 2 }} {{ 1 * 2 }}
+{{1&2}}{{ 1&2 }}{{ 1 &2 }}{{ 1& 2 }} {{ 1 & 2 }}
+{{1|2}}{{ 1|2 }}{{ 1 |2 }}{{ 1| 2 }} {{ 1 | 2 }}
+
+{{true}}{{false}}
+{{!true}}{{ !true }}{{ ! true }}
+{#
+{{true&&false}}{{ true&&false }}{{ true &&false }}{{ true&& false }} {{ true && false }}
+{{true||false}}{{ true||false }}{{ true ||false }}{{ true|| false }} {{ true || false }}
+#}
+
+{{ self.f0() }}{{ self.f0 () }}{{ self.f0 ( ) }}
+{{ self.f1("1") }}{{ self.f1 ( "1" ) }}{{ self.f1 ( "1" ) }}
+{{ self.f2("1","2") }}{{ self.f2 ( "1" ,"2" ) }}{{ self.f2 ( "1" , "2" ) }}
+
+{% for s in 0..5 %}{% endfor %}
+{% for s in 0 .. 5 %}{% endfor %}
+
+{% match option %}
+{% when Option :: Some with ( option ) %}
+{% when std :: option :: Option :: None %}
+{% endmatch %}
+
+{{ std::string::String::new () }}
+{#
+{{ ::std::string::String::new () }}
+#}
+

--- a/testing/tests/allow_whitespaces.rs
+++ b/testing/tests/allow_whitespaces.rs
@@ -1,0 +1,41 @@
+use askama::Template;
+
+#[derive(askama::Template, Default)]
+#[template(path = "allow-whitespaces.html")]
+struct AllowWhitespaces {
+    tuple: (u64, u64, u64, u64),
+    string: &'static str,
+    option: Option<bool>,
+    nested_1: AllowWhitespacesNested1,
+}
+
+#[derive(Default)]
+struct AllowWhitespacesNested1 {
+    nested_2: AllowWhitespacesNested2,
+}
+
+#[derive(Default)]
+struct AllowWhitespacesNested2 {
+    array: &'static [&'static str],
+    hash: std::collections::HashMap<&'static str, &'static str>,
+}
+
+impl AllowWhitespaces {
+    fn f0(&self) -> &str {
+        ""
+    }
+    fn f1(&self, _a: &str) -> &str {
+        ""
+    }
+    fn f2(&self, _a: &str, _b: &str) -> &str {
+        ""
+    }
+}
+
+#[test]
+fn test_allow_whitespaces() {
+    let mut template = AllowWhitespaces::default();
+    template.nested_1.nested_2.array = &["a0", "a1", "a2", "a3"];
+    template.nested_1.nested_2.hash.insert("key", "value");
+    assert_eq!(template.render().unwrap(), "\n0\n0\n0\n0\n\n\n\n0\n0\n0\n0\n0\n\na0\na1\nvalue\n\n\n\n\n\n[\n  \"a0\",\n  \"a1\",\n  \"a2\",\n  \"a3\"\n]\n[\n  \"a0\",\n  \"a1\",\n  \"a2\",\n  \"a3\"\n][\n  \"a0\",\n  \"a1\",\n  \"a2\",\n  \"a3\"\n]\n[\n  \"a1\"\n][\n  \"a1\"\n]\n[\n  \"a1\",\n  \"a2\"\n][\n  \"a1\",\n  \"a2\"\n]\n[][]1-1-1\n3333 3\n2222 2\n0000 0\n3333 3\n\ntruefalse\nfalsefalsefalse\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+}


### PR DESCRIPTION
As reported in #315 at the moment whitespaces aren't allowed in many places where normal Rust would allow them.

This pull request adds support for whitespaces in:
* in function calls: `x ( 1 , 2 )`;
* in path elements: `module :: element`;
* in attributes: `x . y . z`;
* in filter arguments: `x| filter ( 1 , 2 )`;
* before unary operators: `! false` and `- 42`;
* also allow more than a single whitespace;

Also change some tests to include whitespaces in various positions.

As noted in #315 at the moment there is a language ambiguity regarding bitwise or and filter application.  As such at the moment the pipe character `|` should not be preceded by a space when wanting filter application, and must always be preceded when wanting bitwise or.  (This is not a deficiency of the current patch.)
