### PR TITLE
Disable default features of `askama_shared` in `askama_derive`

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -21,7 +21,7 @@ gotham = []
 warp = []
 
 [dependencies]
-askama_shared = { version = "0.10", path = "../askama_shared" }
+askama_shared = { version = "0.10", path = "../askama_shared", default-features = false }
 proc-macro2 = "1"
 quote = "1"
 syn = "1"


### PR DESCRIPTION
3b8bf97cb6da128f020bb557057269661ac89fea disabled default features of `askama_shared` in `askama` but it didn't in `askama_derive`. We'd drop dependencies completely if we could disable there also.