### PR TITLE
tide: use set_error for correct error handling

### DIFF
--- a/askama_tide/src/lib.rs
+++ b/askama_tide/src/lib.rs
@@ -23,9 +23,9 @@ pub fn into_response<T: Template>(t: &T, ext: &str) -> Response {
             response
         }
 
-        Err(e) => {
+        Err(error) => {
             let mut response = Response::new(500);
-            response.set_body(e.to_string());
+            response.set_error(error);
             response
         }
     }


### PR DESCRIPTION
Shortly after askama integrated tide, tide 0.12 introduced the ability to store an error on a Response, allowing applications to inspect, downcast, log, and render the original error instead of serializing to a string. This PR uses Response::set_error to propagate askama errors