### PR TITLE
fix into_f64 and into_isize

### DIFF
--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -249,7 +249,7 @@ pub fn indent(s: &dyn fmt::Display, width: &usize) -> Result<String> {
 
 #[cfg(feature = "num-traits")]
 /// Casts number to f64
-pub fn into_f64<T>(number: T) -> Result<f64>
+pub fn into_f64<T>(number: &T) -> Result<f64>
 where
     T: NumCast,
 {
@@ -258,7 +258,7 @@ where
 
 #[cfg(feature = "num-traits")]
 /// Casts number to isize
-pub fn into_isize<T>(number: T) -> Result<isize>
+pub fn into_isize<T>(number: &T) -> Result<isize>
 where
     T: NumCast,
 {
@@ -460,22 +460,22 @@ mod tests {
     #[test]
     #[allow(clippy::float_cmp)]
     fn test_into_f64() {
-        assert_eq!(into_f64(1).unwrap(), 1.0 as f64);
-        assert_eq!(into_f64(1.9).unwrap(), 1.9 as f64);
-        assert_eq!(into_f64(-1.9).unwrap(), -1.9 as f64);
-        assert_eq!(into_f64(INFINITY as f32).unwrap(), INFINITY);
-        assert_eq!(into_f64(-INFINITY as f32).unwrap(), -INFINITY);
+        assert_eq!(into_f64(&1).unwrap(), 1.0 as f64);
+        assert_eq!(into_f64(&1.9).unwrap(), 1.9 as f64);
+        assert_eq!(into_f64(&-1.9).unwrap(), -1.9 as f64);
+        assert_eq!(into_f64(&(INFINITY as f32)).unwrap(), INFINITY);
+        assert_eq!(into_f64(&(-INFINITY as f32)).unwrap(), -INFINITY);
     }
 
     #[cfg(feature = "num-traits")]
     #[test]
     fn test_into_isize() {
-        assert_eq!(into_isize(1).unwrap(), 1 as isize);
-        assert_eq!(into_isize(1.9).unwrap(), 1 as isize);
-        assert_eq!(into_isize(-1.9).unwrap(), -1 as isize);
-        assert_eq!(into_isize(1.5 as f64).unwrap(), 1 as isize);
-        assert_eq!(into_isize(-1.5 as f64).unwrap(), -1 as isize);
-        match into_isize(INFINITY) {
+        assert_eq!(into_isize(&1).unwrap(), 1 as isize);
+        assert_eq!(into_isize(&1.9).unwrap(), 1 as isize);
+        assert_eq!(into_isize(&-1.9).unwrap(), -1 as isize);
+        assert_eq!(into_isize(&(1.5 as f64)).unwrap(), 1 as isize);
+        assert_eq!(into_isize(&(-1.5 as f64)).unwrap(), -1 as isize);
+        match into_isize(&INFINITY) {
             Err(Fmt(fmt::Error)) => {}
             _ => panic!("Should return error of type Err(Fmt(fmt::Error))"),
         };

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -51,6 +51,20 @@ fn filter_fmt() {
 }
 
 #[derive(Template)]
+#[template(
+    source = "{{ 1|into_f64 }} {{ 1.9|into_isize }}",
+    ext = "txt",
+    escape = "none"
+)]
+struct IntoNumbersTemplate;
+
+#[test]
+fn into_numbers_fmt() {
+    let t = IntoNumbersTemplate;
+    assert_eq!(t.render().unwrap(), "1 1");
+}
+
+#[derive(Template)]
 #[template(source = "{{ s|myfilter }}", ext = "txt")]
 struct MyFilterTemplate<'a> {
     s: &'a str,


### PR DESCRIPTION
askama passes references to the filters (e.g. &f64), and &f64 doesn't
implement NumCast, only f64 does.

So, the filters should take &T instead of T.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>