### PR TITLE
Disable tide default features

### DIFF
--- a/askama_tide/Cargo.toml
+++ b/askama_tide/Cargo.toml
@@ -14,5 +14,5 @@ readme = "README.md"
 
 [dependencies]
 askama = { version = "0.10.2", path = "../askama", features = ["with-tide"] }
-tide = "0.13"
+tide = { version = "0.13", default-features = false, features = ["h1-server"] }
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }


### PR DESCRIPTION
In particular this avoids enabling the tide logger feature.