### PR TITLE
Use `syn::Error::to_compile_error` and add trybuild ui test

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -25,5 +25,4 @@ warp = []
 [dependencies]
 askama_shared = { version = "0.10.4", path = "../askama_shared", default-features = false }
 proc-macro2 = "1"
-quote = "1"
 syn = "1"

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -7,6 +7,7 @@ use askama_shared::{
     generator, get_template_source, read_config_file, CompileError, Config, Integrations,
 };
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -15,11 +16,11 @@ use std::path::PathBuf;
 pub fn derive_template(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
     match build_template(&ast) {
-        Ok(source) => source,
-        Err(e) => format!("compile_error!({:?})", e),
+        Ok(source) => source.parse().unwrap(),
+        Err(e) => syn::Error::new(Span::call_site(), e)
+            .to_compile_error()
+            .into(),
     }
-    .parse()
-    .unwrap()
 }
 
 /// Takes a `syn::DeriveInput` and generates source code for it

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
+trybuild = "1.0"
 
 [[bench]]
 name = "all"

--- a/testing/tests/ui.rs
+++ b/testing/tests/ui.rs
@@ -1,0 +1,7 @@
+use trybuild::TestCases;
+
+#[test]
+fn ui() {
+    let t = TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/testing/tests/ui.rs
+++ b/testing/tests/ui.rs
@@ -1,6 +1,6 @@
 use trybuild::TestCases;
 
-#[test]
+#[cfg_attr(not(windows), test)]
 fn ui() {
     let t = TestCases::new();
     t.compile_fail("tests/ui/*.rs");

--- a/testing/tests/ui/incorrect_path.rs
+++ b/testing/tests/ui/incorrect_path.rs
@@ -1,0 +1,8 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(path = "thisdoesnotexist.html")]
+struct MyTemplate;
+
+fn main() {
+}

--- a/testing/tests/ui/incorrect_path.stderr
+++ b/testing/tests/ui/incorrect_path.stderr
@@ -1,0 +1,7 @@
+error: template "thisdoesnotexist.html" not found in directories ["$WORKSPACE/target/tests/askama_testing/templates"]
+ --> $DIR/incorrect_path.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR only contains one trybuild ui test, others can be added later if desired by putting more files into the `tests/ui/` folder.

Fixes #368 