### PR TITLE
Add test case for `str` cannot be compared to `&str` error (#376)

### DIFF
--- a/testing/templates/macro-import-str-cmp-macro.html
+++ b/testing/templates/macro-import-str-cmp-macro.html
@@ -1,0 +1,7 @@
+{% macro strcmp0(s, other) %}
+{% if s == "foo" %}IT'S FOO{% else if s == other %}it's {{other}}{% else %}it's not foo and not {{other}}{% endif %}
+{% endmacro %}
+
+{% macro strcmp(s) %}
+{% call strcmp0(s, "bar") %}
+{% endmacro %}

--- a/testing/templates/macro-import-str-cmp.html
+++ b/testing/templates/macro-import-str-cmp.html
@@ -1,0 +1,13 @@
+{% import "macro-import-str-cmp-macro.html" as macros %}
+
+TOP
+
+{% call macros::strcmp("foo") %}
+
+CENTER
+
+{% call macros::strcmp("bar") %}
+
+BOTTOM
+
+{% call macros::strcmp("cat") %}

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -43,3 +43,16 @@ fn test_deep_import() {
     let t = DeepImportTemplate;
     assert_eq!(t.render().unwrap(), "foo");
 }
+
+#[derive(Template)]
+#[template(path = "macro-import-str-cmp.html")]
+struct StrCmpTemplate;
+
+#[test]
+fn str_cmp() {
+    let t = StrCmpTemplate;
+    assert_eq!(
+        t.render().unwrap(),
+        "TOP\n\nIT'S FOO\n\nCENTER\n\nIT'S bar\n\nBOTTOM\n\nit's not foo and not bar"
+    );
+}


### PR DESCRIPTION
Error message for this test case:

```
$ cargo test
   Compiling askama_testing v0.1.0 (/home/msrd0/git/askama/testing)
   --> in struct ChildTemplate
   = use of deprecated field '_parent'
   --> in struct ChildTemplate
   = use of deprecated field '_parent'
   --> in struct NestedChildTemplate
   = use of deprecated field '_parent'
   --> in struct DeepMidTemplate
   = use of deprecated field '_parent'
   --> in struct DeepKidTemplate
   = use of deprecated field '_parent'
error[E0277]: can't compare `&&str` with `str`
  --> testing/tests/macro.rs:47:10
   |
47 | #[derive(Template)]
   |          ^^^^^^^^ no implementation for `&&str == str`
   |
   = help: the trait `std::cmp::PartialEq<str>` is not implemented for `&&str`
   = note: required because of the requirements on the impl of `std::cmp::PartialEq<&str>` for `&&&str`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: can't compare `&str` with `str`
  --> testing/tests/macro.rs:47:10
   |
47 | #[derive(Template)]
   |          ^^^^^^^^ no implementation for `&str == str`
   |
   = help: the trait `std::cmp::PartialEq<str>` is not implemented for `&str`
   = note: required because of the requirements on the impl of `std::cmp::PartialEq<&str>` for `&&str`
   = note: required because of the requirements on the impl of `std::cmp::PartialEq<&&str>` for `&&&str`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0277`.
error: could not compile `askama_testing`.

To learn more, run the command again with --verbose.
```