### PR TITLE
Fix urlencode to be usable for URL segments and query keys/values

### DIFF
--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -47,7 +47,7 @@ const URLENCODE_PATH_SET: &AsciiSet = &URLENCODE_SET.remove(b'/');
 // Askama or should refer to a local `filters` module. It should contain all the
 // filters shipped with Askama, even the optional ones (since optional inclusion
 // in the const vector based on features seems impossible right now).
-pub const BUILT_IN_FILTERS: [&str; 25] = [
+pub const BUILT_IN_FILTERS: [&str; 26] = [
     "abs",
     "capitalize",
     "center",
@@ -70,6 +70,7 @@ pub const BUILT_IN_FILTERS: [&str; 25] = [
     "upper",
     "uppercase",
     "urlencode",
+    "urlencode_path",
     "wordcount",
     "json", // Optional feature; reserve the name anyway
     "yaml", // Optional feature; reserve the name anyway

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -122,7 +122,11 @@ pub fn filesizeformat<B: FileSize>(b: &B) -> Result<String> {
 }
 
 #[cfg(feature = "percent-encoding")]
-/// Percent-encodes the argument for safe use in URL; does not encode `/`
+/// Percent-encodes the argument for safe use in URI; does not encode `/`
+///
+/// This should be safe for all parts of URI (paths segments, query keys, query
+/// values). In the rare case that the server can't deal with forward slashes in
+/// the query string, use [`urlencode_strict`], which encodes them as well.
 ///
 /// Encodes all characters except ASCII letters, digits, and `_.-~/`. In other
 /// words, encodes all characters which are not in the unreserved set,
@@ -131,20 +135,22 @@ pub fn filesizeformat<B: FileSize>(b: &B) -> Result<String> {
 ///
 /// ```none,ignore
 /// <a href="/metro{{ "/stations/Château d'Eau" | urlencode }}">Station</a>
+/// <a href="/page?text={{ "look, unicode/emojis ✨" | urlencode }}">Page</a>
 /// ```
 ///
 /// To encode `/` as well, see [`urlencode_strict`](./fn.urlencode_strict.html).
+///
+/// [`urlencode_strict`]: ./fn.urlencode_strict.html
 pub fn urlencode(s: &dyn fmt::Display) -> Result<String> {
     let s = s.to_string();
     Ok(utf8_percent_encode(&s, URLENCODE_SET).to_string())
 }
 
 #[cfg(feature = "percent-encoding")]
-/// Percent-encodes the argument for safe use in URL,
-/// typically used for query keys or values; encodes `/`
+/// Percent-encodes the argument for safe use in URI; encodes `/`
 ///
-/// Use this filter to encode URL query keys or values before
-/// assembling the final URL.
+/// Use this filter for encoding query keys and values in the rare case that
+/// the server can't process them unencoded.
 ///
 /// Encodes all characters except ASCII letters, digits, and `_.-~`. In other
 /// words, encodes all characters which are not in the unreserved set,
@@ -154,7 +160,7 @@ pub fn urlencode(s: &dyn fmt::Display) -> Result<String> {
 /// <a href="/page?text={{ "look, unicode/emojis ✨" | urlencode_strict }}">Page</a>
 /// ```
 ///
-/// If you need to preserve `/`, see [`urlencode`](./fn.urlencode.html).
+/// If you want to preserve `/`, see [`urlencode`](./fn.urlencode.html).
 pub fn urlencode_strict(s: &dyn fmt::Display) -> Result<String> {
     let s = s.to_string();
     Ok(utf8_percent_encode(&s, URLENCODE_STRICT_SET).to_string())

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -39,6 +39,10 @@ const URLENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'-')
     .remove(b'~');
 
+#[cfg(feature = "percent-encoding")]
+// Same as URLENCODE_SET, but preserves forward slashes for encoding paths
+const URLENCODE_PATH_SET: &AsciiSet = &URLENCODE_SET.remove(b'/');
+
 // This is used by the code generator to decide whether a named filter is part of
 // Askama or should refer to a local `filters` module. It should contain all the
 // filters shipped with Askama, even the optional ones (since optional inclusion
@@ -117,19 +121,38 @@ pub fn filesizeformat<B: FileSize>(b: &B) -> Result<String> {
 }
 
 #[cfg(feature = "percent-encoding")]
-/// Encodes the argument for use in URL path or query.
+/// Encodes the argument for use in URL query string
+///
+/// Use this filter to encode URL query keys and query values before
+/// assembling the final URL.
 ///
 /// Percent-encodes all characters except ASCII letters, digits, and `_.-~`.
 ///
-/// Use this filter to encode URL path segments, query keys and query values
-/// before assembling the final URL.
-///
-/// ```ignore
-/// <a href="/page?text={{ val | urlencode }}">Link</a>
+/// ```none,ignore
+/// <a href="/page?text={{ "look, emojis ✨" | urlencode }}">Page</a>
 /// ```
+///
+/// To preserve `/`, use [`urlencode_path`](./fn.urlencode_path.html).
 pub fn urlencode(s: &dyn fmt::Display) -> Result<String> {
     let s = s.to_string();
     Ok(utf8_percent_encode(&s, URLENCODE_SET).to_string())
+}
+
+#[cfg(feature = "percent-encoding")]
+/// Encodes the argument for use in URL path (preserves `/`)
+///
+/// Same as [`urlencode`], but preserves forward slashes.
+///
+/// ```none,ignore
+/// <a href="/metro{{ "/stations/Château d'Eau" | urlencode_path }}">Station</a>
+/// ```
+///
+/// For encoding query strings, use [`urlencode`].
+///
+/// [`urlencode`]: ./fn.urlencode.html
+pub fn urlencode_path(s: &dyn fmt::Display) -> Result<String> {
+    let s = s.to_string();
+    Ok(utf8_percent_encode(&s, URLENCODE_PATH_SET).to_string())
 }
 
 /// Formats arguments according to the specified format
@@ -365,15 +388,22 @@ mod tests {
         // Unreserved (https://tools.ietf.org/html/rfc3986.html#section-2.3)
         // alpha / digit
         assert_eq!(urlencode(&"AZaz09").unwrap(), "AZaz09");
+        assert_eq!(urlencode_path(&"AZaz09").unwrap(), "AZaz09");
         // other
         assert_eq!(urlencode(&"_.-~").unwrap(), "_.-~");
+        assert_eq!(urlencode_path(&"_.-~").unwrap(), "_.-~");
 
         // Reserved (https://tools.ietf.org/html/rfc3986.html#section-2.2)
         // gen-delims
         assert_eq!(urlencode(&":/?#[]@").unwrap(), "%3A%2F%3F%23%5B%5D%40");
+        assert_eq!(urlencode_path(&":/?#[]@").unwrap(), "%3A/%3F%23%5B%5D%40");
         // sub-delims
         assert_eq!(
             urlencode(&"!$&'()*+,;=").unwrap(),
+            "%21%24%26%27%28%29%2A%2B%2C%3B%3D"
+        );
+        assert_eq!(
+            urlencode_path(&"!$&'()*+,;=").unwrap(),
             "%21%24%26%27%28%29%2A%2B%2C%3B%3D"
         );
 
@@ -382,9 +412,14 @@ mod tests {
             urlencode(&"žŠďŤňĚáÉóŮ").unwrap(),
             "%C5%BE%C5%A0%C4%8F%C5%A4%C5%88%C4%9A%C3%A1%C3%89%C3%B3%C5%AE"
         );
+        assert_eq!(
+            urlencode_path(&"žŠďŤňĚáÉóŮ").unwrap(),
+            "%C5%BE%C5%A0%C4%8F%C5%A4%C5%88%C4%9A%C3%A1%C3%89%C3%B3%C5%AE"
+        );
 
         // Ferris
         assert_eq!(urlencode(&"🦀").unwrap(), "%F0%9F%A6%80");
+        assert_eq!(urlencode_path(&"🦀").unwrap(), "%F0%9F%A6%80");
     }
 
     #[test]


### PR DESCRIPTION
Hey!

This PR makes `urlencode` filter behave like [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) and adds `urlencode_path`, which works the same, but preserves `/`.

Previous code behaved like [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI), which should be run on a whole URI and preserves reserved characters which have a special meaning, like `&=?#`. This is typically not what you want: each segment should be urlencoded before joining them into the final URL, so that any reserved characters are safely encoded as data and do not interfere with the URI structure.

Jinja uses an overload, it preserves `/` when encoding strings, but encodes `/` (and replaces spaces by `+`) when encoding key/value pairs for query strings. I don't think encoding spaces in query strings as `+` instead of `%20` is mandatory, but I can add it. I didn't know what would be the best way to handle the slashes, so I added `urlencode_path` filter, which preserves slashes. There might be a better way to do this, like having one filter with a parameter, but I'm not that familiar with what `askama` can do with the filter syntax, so take this only as a proposal.

Another option would be to switch the names and use `urlencode` for slash preserving version (which is closer to the current functionality) and have `urlencode_query` which encodes slashes as well, but it seems that preserving slashes is going to be used less often, so I chose the longer name for it.

Examples
```
<a href="/route/page?key={{ "value/with#=reserved&?chars" | urlencode }}>Link</a>
<a href="/entities/{{ "id!with:symbols" | urlencode }}>Entity</a>
<a href="/files/{{ "path/to/file/ěščřéíáý" | urlencode_path }}>File</a>
```

If there are any use cases which are not covered or are broken by this, please mention them : )