### PR TITLE
Fixed parsing precedence and associativity

### DIFF
--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1080,7 +1080,7 @@ mod tests {
     fn check_ws_split(s: &str, res: &(&str, &str, &str)) {
         let node = super::split_ws_parts(s.as_bytes());
         match node {
-            super::Node::Lit(lws, s, rws) => {
+            Node::Lit(lws, s, rws) => {
                 assert_eq!(lws, res.0);
                 assert_eq!(s, res.1);
                 assert_eq!(rws, res.2);
@@ -1115,12 +1115,9 @@ mod tests {
     fn test_parse_var_call() {
         assert_eq!(
             super::parse("{{ function(\"123\", 3) }}", &Syntax::default()).unwrap(),
-            vec![super::Node::Expr(
-                super::WS(false, false),
-                super::Expr::VarCall(
-                    "function",
-                    vec![super::Expr::StrLit("123"), super::Expr::NumLit("3")]
-                ),
+            vec![Node::Expr(
+                WS(false, false),
+                Expr::VarCall("function", vec![Expr::StrLit("123"), Expr::NumLit("3")]),
             )],
         );
     }
@@ -1129,11 +1126,11 @@ mod tests {
     fn test_parse_path_call() {
         assert_eq!(
             super::parse("{{ self::function(\"123\", 3) }}", &Syntax::default()).unwrap(),
-            vec![super::Node::Expr(
-                super::WS(false, false),
-                super::Expr::PathCall(
+            vec![Node::Expr(
+                WS(false, false),
+                Expr::PathCall(
                     vec!["self", "function"],
-                    vec![super::Expr::StrLit("123"), super::Expr::NumLit("3")],
+                    vec![Expr::StrLit("123"), Expr::NumLit("3")],
                 ),
             )],
         );

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1160,7 +1160,6 @@ mod tests {
                     BinOp("+", Var("a").into(), Var("b").into()).into(),
                     Var("c").into(),
                 )
-                .into()
             )],
         );
         assert_eq!(
@@ -1177,7 +1176,6 @@ mod tests {
                     .into(),
                     BinOp("/", Var("d").into(), Var("e").into()).into(),
                 )
-                .into()
             )],
         );
         assert_eq!(
@@ -1194,7 +1192,6 @@ mod tests {
                     .into(),
                     Unary("-", Var("d").into()).into()
                 )
-                .into()
             )],
         );
         assert_eq!(
@@ -1211,7 +1208,6 @@ mod tests {
                     .into(),
                     BinOp("&&", Var("d").into(), Var("e").into()).into(),
                 )
-                .into()
             )],
         );
     }
@@ -1229,7 +1225,6 @@ mod tests {
                     BinOp("+", Var("a").into(), Var("b").into()).into(),
                     Var("c").into()
                 )
-                .into()
             )],
         );
         assert_eq!(
@@ -1241,7 +1236,6 @@ mod tests {
                     BinOp("*", Var("a").into(), Var("b").into()).into(),
                     Var("c").into()
                 )
-                .into()
             )],
         );
         assert_eq!(
@@ -1253,7 +1247,6 @@ mod tests {
                     BinOp("&&", Var("a").into(), Var("b").into()).into(),
                     Var("c").into()
                 )
-                .into()
             )],
         );
         assert_eq!(
@@ -1270,7 +1263,6 @@ mod tests {
                     .into(),
                     Var("d").into()
                 )
-                .into()
             )],
         );
         assert_eq!(
@@ -1297,7 +1289,6 @@ mod tests {
                     .into(),
                     Var("f").into()
                 )
-                .into()
             )],
         );
     }


### PR DESCRIPTION
Fixes #381

This pull request fixes the parser, such that it produces a correct AST in relation to precedence and associativity.

As mentioned in the issue, given that Askama emits the expressions unmodified, then in that regard there isn't any _noticeable_ change. However, with a correct AST it prevents any potential future problems.

In short `a + b == c` was previously parsed as `(a + (b == c))` and now is correctly parsed as `((a + b) == c)`.

I also added a few test cases to check that the parser upholds precedence and associativity. (If you want the test cases split into multiple functions, then mention it and I'll split them.)

_This does not introduce any breaking changes._