### PR TITLE
Improved if statement generation to avoid issues with implicit borrows

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -518,8 +518,15 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
                         buf.dedent()?;
                         buf.write("} else if ");
                     }
+                    // The following syntax `*(&(...) as &bool)` is used to
+                    // trigger Rust's automatic dereferencing, to coerce
+                    // e.g. `&&&&&bool` to `bool`. First `&(...) as &bool`
+                    // coerces e.g. `&&&bool` to `&bool`. Then `*(&bool)`
+                    // finally dereferences it to `bool`.
+                    buf.write("*(&(");
                     let expr_code = self.visit_expr_root(expr)?;
                     buf.write(&expr_code);
+                    buf.write(") as &bool)");
                 }
                 None => {
                     buf.dedent()?;

--- a/testing/templates/if-coerce.html
+++ b/testing/templates/if-coerce.html
@@ -26,6 +26,26 @@
 {%- call qux(self.f) -%}
 {%- call qux(self.f || self.t) -%}
 
-{%- if true %}t{% else %}f{% endif -%}
-{%- if true && false %}t{% else %}f{% endif -%}
-{%- if false || true %}t{% else %}f{% endif -%}
+{%- if false -%}
+if
+{%- else if false || true -%}
+elseif
+{%- else -%}
+else
+{%- endif -%}
+
+{%- if true && false -%}
+if
+{%- else if false -%}
+elseif
+{%- else -%}
+else
+{%- endif -%}
+
+{%- if false || true -%}
+if
+{%- else if (true && false) -%}
+elseif
+{%- else -%}
+else
+{%- endif -%}

--- a/testing/templates/if-coerce.html
+++ b/testing/templates/if-coerce.html
@@ -1,0 +1,31 @@
+{% macro foo(b) -%}
+    {% if b %}t{% else %}f{% endif -%}
+{% endmacro -%}
+
+{% macro bar(b) -%}
+    {%- call foo(b) -%}
+{% endmacro -%}
+
+{% macro baz(b) -%}
+    {%- call bar(b) -%}
+{% endmacro -%}
+
+{% macro qux(b) -%}
+    {%- call baz(b) -%}
+{% endmacro -%}
+
+{%- call foo(false) -%}
+{%- call bar(true) -%}
+{%- call baz(false) -%}
+{%- call qux(true) -%}
+
+{%- call qux(true && false) -%}
+{%- call qux(false || true) -%}
+
+{%- call qux(self.t) -%}
+{%- call qux(self.f) -%}
+{%- call qux(self.f || self.t) -%}
+
+{%- if true %}t{% else %}f{% endif -%}
+{%- if true && false %}t{% else %}f{% endif -%}
+{%- if false || true %}t{% else %}f{% endif -%}

--- a/testing/tests/coerce.rs
+++ b/testing/tests/coerce.rs
@@ -10,5 +10,5 @@ struct IfCoerceTemplate {
 #[test]
 fn test_coerce() {
     let t = IfCoerceTemplate { t: true, f: false };
-    assert_eq!(t.render().unwrap(), "ftftfttfttft");
+    assert_eq!(t.render().unwrap(), "ftftfttftelseifelseif");
 }

--- a/testing/tests/coerce.rs
+++ b/testing/tests/coerce.rs
@@ -1,0 +1,14 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(path = "if-coerce.html")]
+struct IfCoerceTemplate {
+    t: bool,
+    f: bool,
+}
+
+#[test]
+fn test_coerce() {
+    let t = IfCoerceTemplate { t: true, f: false };
+    assert_eq!(t.render().unwrap(), "ftftfttfttft");
+}


### PR DESCRIPTION
_This does not introduce any breaking changes._

Having an `if` within a `macro` is cumbersome as the parameters are referenced, requiring `if b` to become `if b.clone()`. This becomes even more cumbersome if macros call other macros, requiring various amounts of `.clone()` to be sprinkled at various places.

I changed `write_cond` to utilize Rust's automatic dereferencing rules to coerce e.g. `&bool`, `&&bool`, `&&&bool`, etc. to `bool`. This improves dealing `if b`, as now `.clone()` is no longer needed.

-----

Minimal example to highlight the issue previously:

```jinja
{% macro foo(b) %}
    {% if b %}
    {% endif %}
{% endmacro %}

{% macro bar(b) %}
    {% call foo(b) %}
{% endmacro %}

{% call foo(true) %}
{% call bar(true) %}
```

Which _essentially_ expands to:

```rust
let b = &true;
if b {}
let b = &&true;
if b {}
```

Causing compile errors as `if` expects `bool`:

```rust
error[E0308]: mismatched types
   |
22 | #[derive(Template)]
   |          ^^^^^^^^ expected `bool`, found `&bool`
error[E0308]: mismatched types
   |
22 | #[derive(Template)]
   |          ^^^^^^^^ expected `bool`, found `&&bool`
```

_I also added a new test case, to ensure this behavior persists._