### PR TITLE
Allow paths to start with `::`

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1342,15 +1342,10 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     }
 
     fn visit_path(&mut self, buf: &mut Buffer, path: &[&str]) -> DisplayWrap {
-        let mut it = path.iter();
-        match it.next() {
-            Some(&part) if part != "::" => {
-                buf.write(part);
+        for (i, part) in path.iter().enumerate() {
+            if i > 0 {
+                buf.write("::");
             }
-            _ => {}
-        }
-        for part in it {
-            buf.write("::");
             buf.write(part);
         }
         DisplayWrap::Unwrapped
@@ -1362,15 +1357,10 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         path: &[&str],
         args: &[Expr],
     ) -> Result<DisplayWrap, CompileError> {
-        let mut it = path.iter();
-        match it.next() {
-            Some(&part) if part != "::" => {
-                buf.write(part);
+        for (i, part) in path.iter().enumerate() {
+            if i > 0 {
+                buf.write("::");
             }
-            _ => {}
-        }
-        for part in it {
-            buf.write("::");
             buf.write(part);
         }
         buf.write("(");

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1342,10 +1342,15 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     }
 
     fn visit_path(&mut self, buf: &mut Buffer, path: &[&str]) -> DisplayWrap {
-        for (i, part) in path.iter().enumerate() {
-            if i > 0 {
-                buf.write("::");
+        let mut it = path.iter();
+        match it.next() {
+            Some(&part) if part != "::" => {
+                buf.write(part);
             }
+            _ => {}
+        }
+        for part in it {
+            buf.write("::");
             buf.write(part);
         }
         DisplayWrap::Unwrapped
@@ -1357,10 +1362,15 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         path: &[&str],
         args: &[Expr],
     ) -> Result<DisplayWrap, CompileError> {
-        for (i, part) in path.iter().enumerate() {
-            if i > 0 {
-                buf.write("::");
+        let mut it = path.iter();
+        match it.next() {
+            Some(&part) if part != "::" => {
+                buf.write(part);
             }
+            _ => {}
+        }
+        for part in it {
+            buf.write("::");
             buf.write(part);
         }
         buf.write("(");

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1139,6 +1139,25 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_root_path() {
+        let syntax = Syntax::default();
+        assert_eq!(
+            super::parse("{{ std::string::String::new() }}", &syntax).unwrap(),
+            vec![Node::Expr(
+                WS(false, false),
+                Expr::PathCall(vec!["std", "string", "String", "new"], vec![]),
+            )],
+        );
+        assert_eq!(
+            super::parse("{{ ::std::string::String::new() }}", &syntax).unwrap(),
+            vec![Node::Expr(
+                WS(false, false),
+                Expr::PathCall(vec!["::", "std", "string", "String", "new"], vec![]),
+            )],
+        );
+    }
+
+    #[test]
     fn change_delimiters_parse_filter() {
         let syntax = Syntax {
             expr_start: "{~",

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
 use nom::bytes::complete::{escaped, is_not, tag, take_until};
 use nom::character::complete::{anychar, char, digit1};
-use nom::combinator::{complete, map, opt};
+use nom::combinator::{complete, map, opt, value};
 use nom::error::ParseError;
 use nom::multi::{many0, many1, separated_list0, separated_list1};
 use nom::sequence::{delimited, pair, tuple};
@@ -312,10 +312,12 @@ fn expr_var_call(i: &[u8]) -> IResult<&[u8], Expr> {
 }
 
 fn path(i: &[u8]) -> IResult<&[u8], Vec<&str>> {
+    let root = opt(value("::", ws(tag("::"))));
     let tail = separated_list1(ws(tag("::")), identifier);
-    let (i, (start, _, rest)) = tuple((identifier, ws(tag("::")), tail))(i)?;
-
-    let mut path = vec![start];
+    let (i, (root, start, _, rest)) = tuple((root, identifier, ws(tag("::")), tail))(i)?;
+    let mut path = Vec::new();
+    path.extend(root);
+    path.push(start);
     path.extend(rest);
     Ok((i, path))
 }

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
 use nom::bytes::complete::{escaped, is_not, tag, take_until};
 use nom::character::complete::{anychar, char, digit1};
-use nom::combinator::{complete, map, opt, value};
+use nom::combinator::{complete, map, opt};
 use nom::error::ParseError;
 use nom::multi::{many0, many1, separated_list0, separated_list1};
 use nom::sequence::{delimited, pair, tuple};
@@ -312,12 +312,10 @@ fn expr_var_call(i: &[u8]) -> IResult<&[u8], Expr> {
 }
 
 fn path(i: &[u8]) -> IResult<&[u8], Vec<&str>> {
-    let root = opt(value("::", ws(tag("::"))));
     let tail = separated_list1(ws(tag("::")), identifier);
-    let (i, (root, start, _, rest)) = tuple((root, identifier, ws(tag("::")), tail))(i)?;
-    let mut path = Vec::new();
-    path.extend(root);
-    path.push(start);
+    let (i, (start, _, rest)) = tuple((identifier, ws(tag("::")), tail))(i)?;
+
+    let mut path = vec![start];
     path.extend(rest);
     Ok((i, path))
 }

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
 use nom::bytes::complete::{escaped, is_not, tag, take_until};
 use nom::character::complete::{anychar, char, digit1};
-use nom::combinator::{complete, map, opt};
+use nom::combinator::{complete, map, opt, value};
 use nom::error::ParseError;
 use nom::multi::{many0, many1, separated_list0, separated_list1};
 use nom::sequence::{delimited, pair, tuple};
@@ -312,10 +312,12 @@ fn expr_var_call(i: &[u8]) -> IResult<&[u8], Expr> {
 }
 
 fn path(i: &[u8]) -> IResult<&[u8], Vec<&str>> {
+    let root = opt(value("", ws(tag("::"))));
     let tail = separated_list1(ws(tag("::")), identifier);
-    let (i, (start, _, rest)) = tuple((identifier, ws(tag("::")), tail))(i)?;
-
-    let mut path = vec![start];
+    let (i, (root, start, _, rest)) = tuple((root, identifier, ws(tag("::")), tail))(i)?;
+    let mut path = Vec::new();
+    path.extend(root);
+    path.push(start);
     path.extend(rest);
     Ok((i, path))
 }
@@ -1150,7 +1152,7 @@ mod tests {
             super::parse("{{ ::std::string::String::new() }}", &syntax).unwrap(),
             vec![Node::Expr(
                 WS(false, false),
-                Expr::PathCall(vec!["::", "std", "string", "String", "new"], vec![]),
+                Expr::PathCall(vec!["", "std", "string", "String", "new"], vec![]),
             )],
         );
     }

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -291,6 +291,15 @@ fn test_path_func_call() {
 }
 
 #[derive(Template)]
+#[template(source = "{{ ::std::string::ToString::to_string(123) }}", ext = "txt")]
+struct RootPathFunctionTemplate;
+
+#[test]
+fn test_root_path_func_call() {
+    assert_eq!(RootPathFunctionTemplate.render().unwrap(), "123");
+}
+
+#[derive(Template)]
 #[template(source = "Hello, {{ Self::world3(self, \"123\", 4) }}!", ext = "txt")]
 struct FunctionTemplate;
 


### PR DESCRIPTION
Fixes #331

I wanted to avoid changing `Path` and `PathCall` and the parameters of the visit functions. So instead I decided to just prepend `"::"` to the path parts `Vec`. If you'd rather have I add a `bool` to `Path` and `PathCall` I can do that instead.

_This does not introduce any breaking changes._






