### PR TITLE
Improved template loop generation

### DIFF
--- a/testing/tests/loops.rs
+++ b/testing/tests/loops.rs
@@ -67,3 +67,39 @@ fn test_for_range() {
         "foo (first)\nfoo (last)\nbar\nbar\nfoo\nbar\nbar\n"
     );
 }
+
+#[derive(Template)]
+#[template(source = "{% for i in [1, 2, 3] %}{{ i }}{% endfor %}", ext = "txt")]
+struct ForArrayTemplate {}
+
+#[test]
+fn test_for_array() {
+    let t = ForArrayTemplate {};
+    assert_eq!(t.render().unwrap(), "123");
+}
+
+#[derive(Template)]
+#[template(
+    source = "{% for i in [1, 2, 3].iter() %}{{ i }}{% endfor %}",
+    ext = "txt"
+)]
+struct ForMethodCallTemplate {}
+
+#[test]
+fn test_for_method_call() {
+    let t = ForMethodCallTemplate {};
+    assert_eq!(t.render().unwrap(), "123");
+}
+
+#[derive(Template)]
+#[template(
+    source = "{% for i in [1, 2, 3, 4, 5][3..] %}{{ i }}{% endfor %}",
+    ext = "txt"
+)]
+struct ForIndexTemplate {}
+
+#[test]
+fn test_for_index() {
+    let t = ForIndexTemplate {};
+    assert_eq!(t.render().unwrap(), "45");
+}


### PR DESCRIPTION
Fixes #107
Fixes #333
Closes #221

No test cases were modified, and this is a non-breaking change.

This PR improves the generation of `TemplateLoop`, such that it has a higher chance to produce Rust code that will actually compile, based on assumptions that can be drawn from the context of the expression used. _See the comments in the code, for what those assumptions are._

-----

**Old Explanation (from #396 related to this change):**

> Based on the context of where it is used, what can it be assumed to be?
>    - With loops the assumption can be made that:
>      - `*Call(..)` and `Index(..)` likely return something that implements `IntoIterator` so don't borrow
>      - If not a `*Call(..)` but `self.` is used, then assume it needs to be borrowed
>      - Otherwise, assume that `IntoIterator` is implemented and the value can be moved
