### PR TITLE
Added support for parsing nested comments

### DIFF
--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1329,6 +1329,23 @@ mod tests {
             )],
         );
     }
+
+    #[test]
+    fn test_parse_comments() {
+        let s = &Syntax::default();
+        assert_eq!(
+            super::parse("{#- foo\n bar -#}", s).unwrap(),
+            vec![Node::Comment(WS(true, true))],
+        );
+        assert_eq!(
+            super::parse("{#- foo\n {#- bar\n -#} baz -#}", s).unwrap(),
+            vec![Node::Comment(WS(true, true))],
+        );
+        assert_eq!(
+            super::parse("{# foo {# bar #} {# {# baz #} qux #} #}", s).unwrap(),
+            vec![Node::Comment(WS(false, false))],
+        );
+    }
 }
 
 type ParserError<'a, T> = Result<(&'a [u8], T), nom::Err<nom::error::Error<&'a [u8]>>>;

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -330,8 +330,17 @@ using a vector of templates in a for block.
 
 Askama supports block comments delimited by `{#` and `#}`.
 
-```
+```jinja
 {# A Comment #}
+```
+
+Like Rust, Askama also supports nested block comments.
+
+```jinja
+{#
+A Comment
+{# A nested comment #}
+#}
 ```
 
 ## Recursive Structures


### PR DESCRIPTION
I added support for nested comments, i.e. `{# foo {# bar #} baz #}`. Now Askama is more on par with Rust.

I sometimes comment out chunks of a template when testing stuff. If that chunk already contains comments, then that becomes harder.

- [x] Updated parser
- [x] Added comments test case
- [x] Updated book

Assuming no one has comments like `{# {# #}`, then this is a non-breaking change.
