### PR TITLE
Disable askama's default features in web framework crates

### DIFF
--- a/askama_actix/Cargo.toml
+++ b/askama_actix/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 actix-web = { version = "3", default-features = false }
-askama = { version = "0.10", path = "../askama", features = ["with-actix-web", "mime", "mime_guess"] }
+askama = { version = "0.10", path = "../askama", default-features = false, features = ["with-actix-web", "mime", "mime_guess"] }
 bytes = { version = "0.5" }
 futures-util = { version = "0.3" }
 

--- a/askama_gotham/Cargo.toml
+++ b/askama_gotham/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-askama = { version = "0.10", path = "../askama", features = ["with-gotham", "mime", "mime_guess"] }
+askama = { version = "0.10", path = "../askama", default-features = false, features = ["with-gotham", "mime", "mime_guess"] }
 gotham = { version = "0.5", default-features = false }
 hyper = "0.13"
 

--- a/askama_iron/Cargo.toml
+++ b/askama_iron/Cargo.toml
@@ -14,5 +14,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-askama = { version = "0.10", path = "../askama", features = ["with-iron"] }
+askama = { version = "0.10", path = "../askama", default-features = false, features = ["with-iron"] }
 iron = { version = ">= 0.5, < 0.7" }

--- a/askama_rocket/Cargo.toml
+++ b/askama_rocket/Cargo.toml
@@ -14,5 +14,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-askama = { version = "0.10", path = "../askama", features = ["with-rocket", "mime", "mime_guess"] }
+askama = { version = "0.10", path = "../askama", default-features = false, features = ["with-rocket", "mime", "mime_guess"] }
 rocket = { version = "0.4", default-features = false }

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -206,7 +206,7 @@ impl<'d> RawConfig<'d> {
     }
 
     #[cfg(not(feature = "config"))]
-    fn from_toml_str<'n>(_: &'n str) -> std::result::Result<RawConfig<'_>, CompileError> {
+    fn from_toml_str(_: &str) -> std::result::Result<RawConfig<'_>, CompileError> {
         Err("TOML support not available".into())
     }
 }

--- a/askama_tide/Cargo.toml
+++ b/askama_tide/Cargo.toml
@@ -13,7 +13,7 @@ workspace = ".."
 readme = "README.md"
 
 [dependencies]
-askama = { version = "0.10.2", path = "../askama", features = ["with-tide"] }
+askama = { version = "0.10.2", path = "../askama", default-features = false, features = ["with-tide"] }
 tide = { version = "0.15", default-features = false }
 
 [dev-dependencies]

--- a/askama_warp/Cargo.toml
+++ b/askama_warp/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-askama = { version = "0.10", path = "../askama", features = ["with-warp", "mime", "mime_guess"] }
+askama = { version = "0.10", path = "../askama", default-features = false, features = ["with-warp", "mime", "mime_guess"] }
 warp = { version = "0.2", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Currently it's not possible to disable `askama`'s default features when one of the web framework specific crates is used.

If `Cargo.toml` looks like this, `askama_tide` will enable `askama`'s default features.
```toml
askama = { version = "*", default-features = false, features = ["with-tide"]}
askama_tide = "*"
```

This change will disable `askama`'s default features in `askama_{actix,gotham,iron,rocket,tide,warp}`.

As far as I know, this should only break code that disables default features, but uses them anyway.