### PR TITLE
Added error to hint enabling serde features

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1184,6 +1184,15 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
             return Ok(DisplayWrap::Unwrapped);
         }
 
+        #[cfg(not(feature = "json"))]
+        if name == "json" {
+            return Err("the `json` filter requires the `serde-json` feature to be enabled".into());
+        }
+        #[cfg(not(feature = "yaml"))]
+        if name == "yaml" {
+            return Err("the `yaml` filter requires the `serde-yaml` feature to be enabled".into());
+        }
+
         if name == "escape" || name == "safe" || name == "e" || name == "json" {
             buf.write(&format!(
                 "::askama::filters::{}({}, ",


### PR DESCRIPTION
If `serde-json` or `serde-yaml` is not enabled, while attempting to use the `json` or `yaml` filters, then now an error suggesting to enable them appear. This would help people that don't realize you have to enable the feature(s).

Example:

```jinja
{{ "foo"|json }}
```

Before:

```text
error[E0425]: cannot find function `json` in module `askama::filters`
```

After:

```text
error: the `json` filter requires the `serde-json` feature to be enabled
```
