### PR TITLE
Updated workflow to show each command

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,9 +45,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: |
-          cargo test --package askama_actix --all-targets
-          cargo clippy --package askama_actix --all-targets -- -D warnings
+      - run: cargo test --package askama_actix --all-targets
+      - run: cargo clippy --package askama_actix --all-targets -- -D warnings
 
   Gotham:
     runs-on: ubuntu-latest
@@ -59,9 +58,8 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - run: |
-          cargo test --package askama_gotham --all-targets
-          cargo clippy --package askama_gotham --all-targets -- -D warnings
+      - run: cargo test --package askama_gotham --all-targets
+      - run: cargo clippy --package askama_gotham --all-targets -- -D warnings
 
   Iron:
     runs-on: ubuntu-latest
@@ -73,9 +71,8 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - run: |
-          cargo test --package askama_iron --all-targets
-          cargo clippy --package askama_iron --all-targets -- -D warnings
+      - run: cargo test --package askama_iron --all-targets
+      - run: cargo clippy --package askama_iron --all-targets -- -D warnings
 
   Rocket:
     runs-on: ubuntu-latest
@@ -87,9 +84,8 @@ jobs:
           toolchain: nightly
           override: true
           components: clippy
-      - run: |
-          cargo test --package askama_rocket --all-targets
-          cargo clippy --package askama_rocket --all-targets -- -D warnings
+      - run: cargo test --package askama_rocket --all-targets
+      - run: cargo clippy --package askama_rocket --all-targets -- -D warnings
 
   Warp:
     runs-on: ubuntu-latest
@@ -101,9 +97,8 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - run: |
-          cargo test --package askama_warp --all-targets
-          cargo clippy --package askama_warp --all-targets -- -D warnings
+      - run: cargo test --package askama_warp --all-targets
+      - run: cargo clippy --package askama_warp --all-targets -- -D warnings
 
   Tide:
     runs-on: ubuntu-latest
@@ -115,9 +110,8 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - run: |
-          cargo test --package askama_tide --all-targets
-          cargo clippy --package askama_tide --all-targets -- -D warnings
+      - run: cargo test --package askama_tide --all-targets
+      - run: cargo clippy --package askama_tide --all-targets -- -D warnings
 
   Lint:
     runs-on: ubuntu-latest
@@ -129,6 +123,5 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-      - run: |
-          cargo fmt --all -- --check
-          cargo clippy --all-targets -- -D warnings
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
I've changed the multi-line commands to single-line commands, such that each get their own collapsible section.

When I went to fix #421, it caught me off guard, that it was `cargo fmt` that failed, as instead of inspecting it closer, I just jumped to my own terminal and did `cargo fmt` yielding no issues. You'd have to expand twice to be able to see what commands that step includes.

| Closed | Expanded |
| :------: | :---------: |
| ![closed] | ![expanded] |

[closed]: https://user-images.githubusercontent.com/17464404/103444285-6bde3800-4c67-11eb-817a-5ff57f94f956.png
[expanded]: https://user-images.githubusercontent.com/17464404/103444297-7d274480-4c67-11eb-8b47-697cb8fcb239.png

Whereas now, it will separate e.g. `cargo fmt` and `cargo clippy`, making it more apparent which one failed.

![image](https://user-images.githubusercontent.com/17464404/103444511-1acf4380-4c69-11eb-8faa-0a880797f132.png)
