### PR TITLE
Fixed comment parsing

### DIFF
--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1074,13 +1074,7 @@ fn block_comment<'a>(i: &'a [u8], s: &'a Syntax<'a>) -> IResult<&'a [u8], Node<'
         |i| tag_comment_end(i, s),
     ));
     let (i, (_, pws, tail, _)) = p(i)?;
-    Ok((
-        i,
-        Node::Comment(WS(
-            pws.is_some(),
-            tail.len() > 1 && tail[tail.len() - 1] == b'-',
-        )),
-    ))
+    Ok((i, Node::Comment(WS(pws.is_some(), tail.ends_with(b"-")))))
 }
 
 fn parse_template<'a>(i: &'a [u8], s: &'a Syntax<'a>) -> IResult<&'a [u8], Vec<Node<'a>>> {

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -1415,6 +1415,24 @@ mod tests {
     #[test]
     fn test_parse_comments() {
         let s = &Syntax::default();
+
+        assert_eq!(
+            super::parse("{##}", s).unwrap(),
+            vec![Node::Comment(WS(false, false))],
+        );
+        assert_eq!(
+            super::parse("{#- #}", s).unwrap(),
+            vec![Node::Comment(WS(true, false))],
+        );
+        assert_eq!(
+            super::parse("{# -#}", s).unwrap(),
+            vec![Node::Comment(WS(false, true))],
+        );
+        assert_eq!(
+            super::parse("{#--#}", s).unwrap(),
+            vec![Node::Comment(WS(true, true))],
+        );
+
         assert_eq!(
             super::parse("{#- foo\n bar -#}", s).unwrap(),
             vec![Node::Comment(WS(true, true))],


### PR DESCRIPTION
Before `{#--#}` was parsed as `{#- #}`.
