### PR TITLE
Changed so uppercase variables passthrough as constants

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1721,8 +1721,11 @@ impl MapChain<'_, &str, LocalMeta> {
     }
 
     fn resolve_or_self(&self, name: &str) -> String {
-        self.resolve(name)
-            .unwrap_or_else(|| format!("self.{}", name))
+        match self.resolve(name) {
+            Some(name) => name,
+            None if name.chars().any(char::is_uppercase) => name.to_string(),
+            None => format!("self.{}", name),
+        }
     }
 }
 

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -73,6 +73,36 @@ fn test_variables_no_escape() {
 }
 
 #[derive(Template)]
+#[template(
+    source = "{{ foo }} {{ foo_bar }} {{ FOO }} {{ FOO_BAR }} {{ self::FOO }} {{ self::FOO_BAR }} {{ Self::BAR }} {{ Self::BAR_BAZ }}",
+    ext = "txt"
+)]
+struct ConstTemplate {
+    foo: &'static str,
+    foo_bar: &'static str,
+}
+
+impl ConstTemplate {
+    const BAR: &'static str = "BAR";
+    const BAR_BAZ: &'static str = "BAR BAZ";
+}
+
+#[test]
+fn test_constants() {
+    let t = ConstTemplate {
+        foo: "foo",
+        foo_bar: "foo bar",
+    };
+    assert_eq!(
+        t.render().unwrap(),
+        "foo foo bar FOO FOO BAR FOO FOO BAR BAR BAR BAZ"
+    );
+}
+
+const FOO: &str = "FOO";
+const FOO_BAR: &str = "FOO BAR";
+
+#[derive(Template)]
 #[template(path = "if.html")]
 struct IfTemplate {
     cond: bool,


### PR DESCRIPTION
Resolves #432

Fixes so that variables including an uppercase letter, doesn't get prefixed `self.`, i.e. `{{ FOO }}` results in `FOO` instead of `self.FOO`.
