### PR TITLE
I18n

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -38,6 +38,8 @@ askama_escape = { version = "0.10", path = "../askama_escape" }
 askama_shared = { version = "0.11", path = "../askama_shared", default-features = false }
 mime = { version = "0.3", optional = true }
 mime_guess = { version = "2.0.0-alpha", optional = true }
+unic-langid = "0.9.0"
+fluent-templates = "0.5.16"
 
 [package.metadata.docs.rs]
 features = ["config", "humansize", "num-traits", "serde-json", "serde-yaml"]

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -12,7 +12,7 @@ use proc_macro2::Span;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[proc_macro_derive(Template, attributes(template))]
+#[proc_macro_derive(Template, attributes(template, localizer))]
 pub fn derive_template(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
     match build_template(&ast) {

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1407,16 +1407,8 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
 
         self.localized_messages.insert(message.clone());
 
-        /*
         buf.write(&format!(
-            "::askama::Localize::localize(&self.{}, \"{}\", &[",
-            localizer.0, message
-        ));
-        */
-        // TODO
-
-        buf.write(&format!(
-            "::fluent_templates::Loader::lookup_with_args(&self.{}.0, &self.{}.1, \"{}\", &std::iter::FromIterator::from_iter(vec![",
+            "::fluent_templates::Loader::lookup_with_args(::askama::Localizer::get_loader(&self.{}), &::askama::Localizer::get_language(&self.{}), \"{}\", &std::iter::FromIterator::from_iter(vec![",
             localizer.0, localizer.0, message
         ));
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -12,6 +12,8 @@ default = ["serde_json", "askama/serde-json"]
 [dependencies]
 askama = { path = "../askama", version = "*" }
 serde_json = { version = "1.0", optional = true }
+fluent-templates = "0.5.16"
+unic-langid = "0.9.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/testing/i18n-basic/en-US/basic.ftl
+++ b/testing/i18n-basic/en-US/basic.ftl
@@ -1,0 +1,2 @@
+greeting = Hello, { $name }! 
+age = You are { $hours } hours old.

--- a/testing/i18n-basic/es-MX/basic.ftl
+++ b/testing/i18n-basic/es-MX/basic.ftl
@@ -1,0 +1,3 @@
+greeting = ¡Hola, { $name }!
+
+age = Tienes { $hours } horas.

--- a/testing/templates/i18n.html
+++ b/testing/templates/i18n.html
@@ -1,0 +1,2 @@
+<h1>{{ localize(greeting, name: name) }}</h1>
+<h3>{{ localize(age, hours: hours ) }}</h3>

--- a/testing/templates/i18n_invalid.html
+++ b/testing/templates/i18n_invalid.html
@@ -1,0 +1,2 @@
+<h1>{{ localize(greetingsss, name: name) }}</h1>
+<h3>{{ localize(ages) }}</h3>

--- a/testing/tests/i18n.rs
+++ b/testing/tests/i18n.rs
@@ -17,6 +17,14 @@ init_translation! {
 }
 
 #[derive(Template)]
+#[template(path = "i18n_invalid.html")]
+struct UsesI18nInvalid<'a> {
+    #[localizer]
+    loc: MyLocalizer,
+    name: &'a str,
+}
+
+#[derive(Template)]
 #[template(path = "i18n.html")]
 struct UsesI18n<'a> {
     #[localizer]
@@ -28,7 +36,7 @@ struct UsesI18n<'a> {
 #[test]
 fn existing_language() {
     let template = UsesI18n {
-        loc: MyLocalizer::new(unic_langid::langid!("es-MX"), &LOCALES),
+        loc: MyLocalizer::new(unic_langid::langid!("es-MX")),
         name: "Hilda",
         hours: 300072.3,
     };
@@ -42,7 +50,7 @@ fn existing_language() {
 #[test]
 fn unknown_language() {
     let template = UsesI18n {
-        loc: MyLocalizer::new(unic_langid::langid!("nl-BE"), &LOCALES),
+        loc: MyLocalizer::new(unic_langid::langid!("nl-BE")),
         name: "Hilda",
         hours: 300072.3,
     };

--- a/testing/tests/i18n.rs
+++ b/testing/tests/i18n.rs
@@ -4,31 +4,23 @@
 #![allow(unused)]
 */
 
+use askama::init_translation;
 use askama::Template;
 
-fluent_templates::static_loader! {
-    // Declare our `StaticLoader` named `LOCALES`.
-    static LOCALES = {
-        // The directory of localisations and fluent resources.
+init_translation! {
+    pub MyLocalizer {
+        static_loader_name: LOCALES,
         locales: "i18n-basic",
-        // The language to falback on if something is not present.
         fallback_language: "en-US",
-        // Optional: A fluent resource that is shared with every locale.
-        //core_locales: "/core.ftl",
-        // Removes unicode isolating marks around arguments, you typically
-        // should only set to false when testing.
-        customise: |bundle| bundle.set_use_isolating(false),
-    };
+        customise: |bundle| bundle.set_use_isolating(false)
+    }
 }
 
 #[derive(Template)]
 #[template(path = "i18n.html")]
 struct UsesI18n<'a> {
     #[localizer]
-    loc: (
-        &'a fluent_templates::StaticLoader,
-        &'a unic_langid::LanguageIdentifier,
-    ),
+    loc: MyLocalizer,
     name: &'a str,
     hours: f64,
 }
@@ -36,7 +28,7 @@ struct UsesI18n<'a> {
 #[test]
 fn existing_language() {
     let template = UsesI18n {
-        loc: (&LOCALES, &unic_langid::langid!("es-MX")),
+        loc: MyLocalizer::new(unic_langid::langid!("es-MX"), &LOCALES),
         name: "Hilda",
         hours: 300072.3,
     };
@@ -50,7 +42,7 @@ fn existing_language() {
 #[test]
 fn unknown_language() {
     let template = UsesI18n {
-        loc: (&LOCALES, &unic_langid::langid!("nl-BE")),
+        loc: MyLocalizer::new(unic_langid::langid!("nl-BE"), &LOCALES),
         name: "Hilda",
         hours: 300072.3,
     };

--- a/testing/tests/i18n.rs
+++ b/testing/tests/i18n.rs
@@ -1,0 +1,62 @@
+// TODO
+/*
+#![cfg(feature = "with-i18n")]
+#![allow(unused)]
+*/
+
+use askama::Template;
+
+fluent_templates::static_loader! {
+    // Declare our `StaticLoader` named `LOCALES`.
+    static LOCALES = {
+        // The directory of localisations and fluent resources.
+        locales: "i18n-basic",
+        // The language to falback on if something is not present.
+        fallback_language: "en-US",
+        // Optional: A fluent resource that is shared with every locale.
+        //core_locales: "/core.ftl",
+        // Removes unicode isolating marks around arguments, you typically
+        // should only set to false when testing.
+        customise: |bundle| bundle.set_use_isolating(false),
+    };
+}
+
+#[derive(Template)]
+#[template(path = "i18n.html")]
+struct UsesI18n<'a> {
+    #[localizer]
+    loc: (
+        &'a fluent_templates::StaticLoader,
+        &'a unic_langid::LanguageIdentifier,
+    ),
+    name: &'a str,
+    hours: f64,
+}
+
+#[test]
+fn existing_language() {
+    let template = UsesI18n {
+        loc: (&LOCALES, &unic_langid::langid!("es-MX")),
+        name: "Hilda",
+        hours: 300072.3,
+    };
+    assert_eq!(
+        template.render().unwrap(),
+        r#"<h1>¡Hola, Hilda!</h1>
+<h3>Tienes 300072.3 horas.</h3>"#
+    )
+}
+
+#[test]
+fn unknown_language() {
+    let template = UsesI18n {
+        loc: (&LOCALES, &unic_langid::langid!("nl-BE")),
+        name: "Hilda",
+        hours: 300072.3,
+    };
+    assert_eq!(
+        template.render().unwrap(),
+        r#"<h1>Hello, Hilda!</h1>
+<h3>You are 300072.3 hours old.</h3>"#
+    )
+}


### PR DESCRIPTION
This (draft) PR gives an initial onset for localization (#202) by using [fluent-templates](https://github.com/XAMPPRocky/fluent-templates) to statically load all fluent translations.
It is based on code of @kazimuth 

@djc Could you give some quick remarks / questions?

**TODO**
- [ ] Add `with-i18n` features
- [ ] Fix the test for invalid `text_id`'s (the test fails, as it should, but we should assert that it fails instead of failing)
- [ ] Look into a better way to check if translations exist (currently catches a panic of fluent-templates, maybe they should use a Result?)
- [ ] Documentation
- [ ] Improve `init_translations` macro
- [ ] Go through all remaining TODO comments