### PR TITLE
Fix bitvec broken dependency temporarily Fixes #446

### DIFF
--- a/askama_shared/Cargo.toml
+++ b/askama_shared/Cargo.toml
@@ -19,6 +19,7 @@ yaml = ["serde", "serde_yaml"]
 [dependencies]
 askama_escape = { version = "0.10", path = "../askama_escape" }
 humansize = { version = "1.1.0", optional = true }
+funty = "=1.1.0" # Temporary fix for bitvec, remove once fixed. (https://github.com/bitvecto-rs/bitvec/issues/105)
 nom = { version = "6", features = ["std"], default-features = false }
 num-traits = { version = "0.2.6", optional = true }
 proc-macro2 = "1"


### PR DESCRIPTION
Fixes https://github.com/djc/askama/issues/446

Related: https://github.com/bitvecto-rs/bitvec/issues/105

Maybe you should make a quick release.