### PR TITLE
Reworked constants to be parsed as paths

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1723,11 +1723,8 @@ impl MapChain<'_, &str, LocalMeta> {
     }
 
     fn resolve_or_self(&self, name: &str) -> String {
-        match self.resolve(name) {
-            Some(name) => name,
-            None if name.chars().any(char::is_uppercase) => name.to_string(),
-            None => format!("self.{}", name),
-        }
+        self.resolve(name)
+            .unwrap_or_else(|| format!("self.{}", name))
     }
 }
 


### PR DESCRIPTION
As discussed on #453.

- Refactored `Expr::Var` into `Expr::Var` and `Expr::Const`
- Updated parser test cases

I didn't do `Expr::Field` (yet?), because it would require moving a significant amount of the logic from the generator into the parser. Which first of all, I don't think that logic belongs in the parser. However, it might be possible to have an intermediate step between the parser and generator. To possibly have some simple form of IR. Essentially to be able to simplify what the generator receives and operates on, instead of AST.

That might even be useful if we wanted to add support for handlebars (#395)
