### PR TITLE
 Use raw identifiers for identifiers which collide with Rust keywords

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1755,35 +1755,59 @@ enum Writable<'a> {
 // because they are not allowed to be raw identifiers, and *loop*
 // because it's used something like a keyword in the template
 // language.
-#[rustfmt::skip]
-static USE_RAW: [&str; 47] = [
-    "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
-    "if", "impl", "in", "let", "match", "mod", "move", "mut", "pub", "ref", "return",
-    "static", "struct", "trait", "true", "type", "unsafe", "use", "where",
-    "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
-    "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
-];
-
-// The raw identifier versions of the USE_RAW identifiers. The indices
-// of the identifier and raw identifier must be the same, so any
-// modification made to one of the arrays must be mirrored in the
-// other array. We're doing it that way, rather than using a more
-// advanced data structure, because statically initializing more
-// advanced data structures requires extra dependencies like once_cell
-// or lazy_static. We need the AS_RAW strings to be static so we can
-// substitute them for the parsed identifiers.
-#[rustfmt::skip]
-static AS_RAW: [&str; 47] = [
-    "r#as", "r#break", "r#const", "r#continue", "r#crate", "r#else", "r#enum", "r#extern", "r#false", "r#fn", "r#for",
-    "r#if", "r#impl", "r#in", "r#let", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
-    "r#static", "r#struct", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
-    "r#while", "r#async", "r#await", "r#dyn", "r#abstract", "r#become", "r#box", "r#do", "r#final", "r#macro",
-    "r#override", "r#priv", "r#typeof", "r#unsized", "r#virtual", "r#yield", "r#try",
+static USE_RAW: [(&str, &str); 47] = [
+    ("as", "r#as"),
+    ("break", "r#break"),
+    ("const", "r#const"),
+    ("continue", "r#continue"),
+    ("crate", "r#crate"),
+    ("else", "r#else"),
+    ("enum", "r#enum"),
+    ("extern", "r#extern"),
+    ("false", "r#false"),
+    ("fn", "r#fn"),
+    ("for", "r#for"),
+    ("if", "r#if"),
+    ("impl", "r#impl"),
+    ("in", "r#in"),
+    ("let", "r#let"),
+    ("match", "r#match"),
+    ("mod", "r#mod"),
+    ("move", "r#move"),
+    ("mut", "r#mut"),
+    ("pub", "r#pub"),
+    ("ref", "r#ref"),
+    ("return", "r#return"),
+    ("static", "r#static"),
+    ("struct", "r#struct"),
+    ("trait", "r#trait"),
+    ("true", "r#true"),
+    ("type", "r#type"),
+    ("unsafe", "r#unsafe"),
+    ("use", "r#use"),
+    ("where", "r#where"),
+    ("while", "r#while"),
+    ("async", "r#async"),
+    ("await", "r#await"),
+    ("dyn", "r#dyn"),
+    ("abstract", "r#abstract"),
+    ("become", "r#become"),
+    ("box", "r#box"),
+    ("do", "r#do"),
+    ("final", "r#final"),
+    ("macro", "r#macro"),
+    ("override", "r#override"),
+    ("priv", "r#priv"),
+    ("typeof", "r#typeof"),
+    ("unsized", "r#unsized"),
+    ("virtual", "r#virtual"),
+    ("yield", "r#yield"),
+    ("try", "r#try"),
 ];
 
 fn normalize_identifier(ident: &str) -> &str {
-    if let Some(index) = USE_RAW.iter().position(|x| *x == ident) {
-        AS_RAW[index]
+    if let Some(word) = USE_RAW.iter().find(|x| x.0 == ident) {
+        word.1
     } else {
         ident
     }

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -14,51 +14,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::{cmp, hash, mem, str};
 
-// Identifiers to be replaced with raw identifiers, so as to avoid
-// collisions between template syntax and Rust's syntax. In particular
-// [Rust keywords](https://doc.rust-lang.org/reference/keywords.html)
-// should be replaced, since they're not reserved words in Askama
-// syntax but have a high probability of causing problems in the
-// generated code.
-//
-// This list excludes the Rust keywords *self*, *Self*, and *super*
-// because they are not allowed to be raw identifiers, and *loop*
-// because it's used something like a keyword in the template
-// language.
-#[rustfmt::skip]
-static USE_RAW: [&str; 47] = [
-    "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
-    "if", "impl", "in", "let", "match", "mod", "move", "mut", "pub", "ref", "return",
-    "static", "struct", "trait", "true", "type", "unsafe", "use", "where",
-    "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
-    "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
-];
-
-// The raw identifier versions of the USE_RAW identifiers. The indices
-// of the identifier and raw identifier must be the same, so any
-// modification made to one of the arrays must be mirrored in the
-// other array. We're doing it that way, rather than using a more
-// advanced data structure, because statically initializing more
-// advanced data structures requires extra dependencies like once_cell
-// or lazy_static. We need the AS_RAW strings to be static so we can
-// substitute them for the parsed identifiers.
-#[rustfmt::skip]
-static AS_RAW: [&str; 47] = [
-    "r#as", "r#break", "r#const", "r#continue", "r#crate", "r#else", "r#enum", "r#extern", "r#false", "r#fn", "r#for",
-    "r#if", "r#impl", "r#in", "r#let", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
-    "r#static", "r#struct", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
-    "r#while", "r#async", "r#await", "r#dyn", "r#abstract", "r#become", "r#box", "r#do", "r#final", "r#macro",
-    "r#override", "r#priv", "r#typeof", "r#unsized", "r#virtual", "r#yield", "r#try",
-];
-
-fn normalize_identifier(ident: &str) -> &str {
-    if let Some(index) = USE_RAW.iter().position(|x| *x == ident) {
-        AS_RAW[index]
-    } else {
-        ident
-    }
-}
-
 pub fn generate<S: std::hash::BuildHasher>(
     input: &TemplateInput,
     contexts: &HashMap<&PathBuf, Context, S>,
@@ -1787,4 +1742,49 @@ impl Copy for DisplayWrap {}
 enum Writable<'a> {
     Lit(&'a str),
     Expr(&'a Expr<'a>),
+}
+
+// Identifiers to be replaced with raw identifiers, so as to avoid
+// collisions between template syntax and Rust's syntax. In particular
+// [Rust keywords](https://doc.rust-lang.org/reference/keywords.html)
+// should be replaced, since they're not reserved words in Askama
+// syntax but have a high probability of causing problems in the
+// generated code.
+//
+// This list excludes the Rust keywords *self*, *Self*, and *super*
+// because they are not allowed to be raw identifiers, and *loop*
+// because it's used something like a keyword in the template
+// language.
+#[rustfmt::skip]
+static USE_RAW: [&str; 47] = [
+    "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
+    "if", "impl", "in", "let", "match", "mod", "move", "mut", "pub", "ref", "return",
+    "static", "struct", "trait", "true", "type", "unsafe", "use", "where",
+    "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
+    "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
+];
+
+// The raw identifier versions of the USE_RAW identifiers. The indices
+// of the identifier and raw identifier must be the same, so any
+// modification made to one of the arrays must be mirrored in the
+// other array. We're doing it that way, rather than using a more
+// advanced data structure, because statically initializing more
+// advanced data structures requires extra dependencies like once_cell
+// or lazy_static. We need the AS_RAW strings to be static so we can
+// substitute them for the parsed identifiers.
+#[rustfmt::skip]
+static AS_RAW: [&str; 47] = [
+    "r#as", "r#break", "r#const", "r#continue", "r#crate", "r#else", "r#enum", "r#extern", "r#false", "r#fn", "r#for",
+    "r#if", "r#impl", "r#in", "r#let", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
+    "r#static", "r#struct", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
+    "r#while", "r#async", "r#await", "r#dyn", "r#abstract", "r#become", "r#box", "r#do", "r#final", "r#macro",
+    "r#override", "r#priv", "r#typeof", "r#unsized", "r#virtual", "r#yield", "r#try",
+];
+
+fn normalize_identifier(ident: &str) -> &str {
+    if let Some(index) = USE_RAW.iter().position(|x| *x == ident) {
+        AS_RAW[index]
+    } else {
+        ident
+    }
 }

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -6,7 +6,7 @@ use nom::error::{Error, ParseError};
 use nom::multi::{many0, many1, separated_list0, separated_list1};
 use nom::sequence::{delimited, pair, tuple};
 use nom::{self, error_position, Compare, IResult, InputTake};
-use std::{ops::Index, str};
+use std::str;
 
 use crate::{CompileError, Syntax};
 
@@ -17,7 +17,7 @@ use crate::{CompileError, Syntax};
 // syntax but have a high probability of causing problems in the
 // generated code.
 #[rustfmt::skip]
-static USE_RAW: [&'static str; 51] = [
+static USE_RAW: [&str; 51] = [
     "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
     "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
     "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe", "use", "where",
@@ -34,7 +34,7 @@ static USE_RAW: [&'static str; 51] = [
 // or lazy_static. We need the AS_RAW strings to be static so we can
 // substitute them for the parsed identifiers.
 #[rustfmt::skip]
-static AS_RAW: [&'static str; 51] = [
+static AS_RAW: [&str; 51] = [
     "r#as", "r#break", "r#const", "r#continue", "r#crate", "r#else", "r#enum", "r#extern", "r#false", "r#fn", "r#for",
     "r#if", "r#impl", "r#in", "r#let", "r#loop", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
     "r#self", "r#Self", "r#static", "r#struct", "r#super", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -10,51 +10,6 @@ use std::str;
 
 use crate::{CompileError, Syntax};
 
-// Identifiers to be replaced with raw identifiers, so as to avoid
-// collisions between template syntax and Rust's syntax. In particular
-// [Rust keywords](https://doc.rust-lang.org/reference/keywords.html)
-// should be replaced, since they're not reserved words in Askama
-// syntax but have a high probability of causing problems in the
-// generated code.
-//
-// This list excludes the Rust keywords *self*, *Self*, and *super*
-// because they are not allowed to be raw identifiers, and *loop*
-// because it's used something like a keyword in the template
-// language.
-#[rustfmt::skip]
-static USE_RAW: [&str; 47] = [
-    "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
-    "if", "impl", "in", "let", "match", "mod", "move", "mut", "pub", "ref", "return",
-    "static", "struct", "trait", "true", "type", "unsafe", "use", "where",
-    "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
-    "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
-];
-
-// The raw identifier versions of the USE_RAW identifiers. The indices
-// of the identifier and raw identifier must be the same, so any
-// modification made to one of the arrays must be mirrored in the
-// other array. We're doing it that way, rather than using a more
-// advanced data structure, because statically initializing more
-// advanced data structures requires extra dependencies like once_cell
-// or lazy_static. We need the AS_RAW strings to be static so we can
-// substitute them for the parsed identifiers.
-#[rustfmt::skip]
-static AS_RAW: [&str; 47] = [
-    "r#as", "r#break", "r#const", "r#continue", "r#crate", "r#else", "r#enum", "r#extern", "r#false", "r#fn", "r#for",
-    "r#if", "r#impl", "r#in", "r#let", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
-    "r#static", "r#struct", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
-    "r#while", "r#async", "r#await", "r#dyn", "r#abstract", "r#become", "r#box", "r#do", "r#final", "r#macro",
-    "r#override", "r#priv", "r#typeof", "r#unsized", "r#virtual", "r#yield", "r#try",
-];
-
-fn normalize_identifier(ident: &str) -> &str {
-    if let Some(index) = USE_RAW.iter().position(|x| *x == ident) {
-        AS_RAW[index]
-    } else {
-        ident
-    }
-}
-
 #[derive(Debug, PartialEq)]
 pub enum Node<'a> {
     Lit(&'a str, &'a str, &'a str),
@@ -299,15 +254,9 @@ fn identifier(input: &[u8]) -> ParserError<&str> {
         if i == 0 || nom::character::is_alphanumeric(*ch) || *ch == b'_' || non_ascii(*ch) {
             continue;
         }
-        return Ok((
-            &input[i..],
-            normalize_identifier(str::from_utf8(&input[..i]).unwrap()),
-        ));
+        return Ok((&input[i..], str::from_utf8(&input[..i]).unwrap()));
     }
-    Ok((
-        &input[1..],
-        normalize_identifier(str::from_utf8(&input[..1]).unwrap()),
-    ))
+    Ok((&input[1..], str::from_utf8(&input[..1]).unwrap()))
 }
 
 #[inline]

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -17,10 +17,10 @@ use crate::{CompileError, Syntax};
 // syntax but have a high probability of causing problems in the
 // generated code.
 #[rustfmt::skip]
-static USE_RAW: [&str; 51] = [
+static USE_RAW: [&str; 49] = [
     "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
     "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
-    "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe", "use", "where",
+    "Self", "static", "struct", "trait", "true", "type", "unsafe", "use", "where",
     "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
     "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
 ];
@@ -34,10 +34,10 @@ static USE_RAW: [&str; 51] = [
 // or lazy_static. We need the AS_RAW strings to be static so we can
 // substitute them for the parsed identifiers.
 #[rustfmt::skip]
-static AS_RAW: [&str; 51] = [
+static AS_RAW: [&str; 49] = [
     "r#as", "r#break", "r#const", "r#continue", "r#crate", "r#else", "r#enum", "r#extern", "r#false", "r#fn", "r#for",
     "r#if", "r#impl", "r#in", "r#let", "r#loop", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
-    "r#self", "r#Self", "r#static", "r#struct", "r#super", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
+    "r#Self", "r#static", "r#struct", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
     "r#while", "r#async", "r#await", "r#dyn", "r#abstract", "r#become", "r#box", "r#do", "r#final", "r#macro",
     "r#override", "r#priv", "r#typeof", "r#unsized", "r#virtual", "r#yield", "r#try",
 ];

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -17,10 +17,10 @@ use crate::{CompileError, Syntax};
 // syntax but have a high probability of causing problems in the
 // generated code.
 #[rustfmt::skip]
-static USE_RAW: [&str; 49] = [
+static USE_RAW: [&str; 48] = [
     "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
     "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
-    "Self", "static", "struct", "trait", "true", "type", "unsafe", "use", "where",
+    "static", "struct", "trait", "true", "type", "unsafe", "use", "where",
     "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
     "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
 ];
@@ -34,10 +34,10 @@ static USE_RAW: [&str; 49] = [
 // or lazy_static. We need the AS_RAW strings to be static so we can
 // substitute them for the parsed identifiers.
 #[rustfmt::skip]
-static AS_RAW: [&str; 49] = [
+static AS_RAW: [&str; 48] = [
     "r#as", "r#break", "r#const", "r#continue", "r#crate", "r#else", "r#enum", "r#extern", "r#false", "r#fn", "r#for",
     "r#if", "r#impl", "r#in", "r#let", "r#loop", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
-    "r#Self", "r#static", "r#struct", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
+    "r#static", "r#struct", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
     "r#while", "r#async", "r#await", "r#dyn", "r#abstract", "r#become", "r#box", "r#do", "r#final", "r#macro",
     "r#override", "r#priv", "r#typeof", "r#unsized", "r#virtual", "r#yield", "r#try",
 ];

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -16,10 +16,15 @@ use crate::{CompileError, Syntax};
 // should be replaced, since they're not reserved words in Askama
 // syntax but have a high probability of causing problems in the
 // generated code.
+//
+// This list excludes the Rust keywords *self*, *Self*, and *super*
+// because they are not allowed to be raw identifiers, and *loop*
+// because it's used something like a keyword in the template
+// language.
 #[rustfmt::skip]
-static USE_RAW: [&str; 48] = [
+static USE_RAW: [&str; 47] = [
     "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
-    "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
+    "if", "impl", "in", "let", "match", "mod", "move", "mut", "pub", "ref", "return",
     "static", "struct", "trait", "true", "type", "unsafe", "use", "where",
     "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
     "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
@@ -34,9 +39,9 @@ static USE_RAW: [&str; 48] = [
 // or lazy_static. We need the AS_RAW strings to be static so we can
 // substitute them for the parsed identifiers.
 #[rustfmt::skip]
-static AS_RAW: [&str; 48] = [
+static AS_RAW: [&str; 47] = [
     "r#as", "r#break", "r#const", "r#continue", "r#crate", "r#else", "r#enum", "r#extern", "r#false", "r#fn", "r#for",
-    "r#if", "r#impl", "r#in", "r#let", "r#loop", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
+    "r#if", "r#impl", "r#in", "r#let", "r#match", "r#mod", "r#move", "r#mut", "r#pub", "r#ref", "r#return",
     "r#static", "r#struct", "r#trait", "r#true", "r#type", "r#unsafe", "r#use", "r#where",
     "r#while", "r#async", "r#await", "r#dyn", "r#abstract", "r#become", "r#box", "r#do", "r#final", "r#macro",
     "r#override", "r#priv", "r#typeof", "r#unsized", "r#virtual", "r#yield", "r#try",


### PR DESCRIPTION
Rust keywords are valid identifier names in templates, so allow the template expansions to use those identifiers safely, by turning them into raw identifiers during the parse stage.