### PR TITLE
Remove forward-slash escape

### DIFF
--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -129,7 +129,6 @@ impl Escaper for Html {
                     b'&' => escaping_body!(start, i, fmt, bytes, "&amp;"),
                     b'"' => escaping_body!(start, i, fmt, bytes, "&quot;"),
                     b'\'' => escaping_body!(start, i, fmt, bytes, "&#x27;"),
-                    b'/' => escaping_body!(start, i, fmt, bytes, "&#x2f;"),
                     _ => (),
                 }
             }

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -21,7 +21,7 @@ fn filter_escape() {
     };
     assert_eq!(
         s.render().unwrap(),
-        "&#x2f;&#x2f; my &lt;html&gt; is &quot;unsafe&quot; &amp; \
+        "// my &lt;html&gt; is &quot;unsafe&quot; &amp; \
          should be &#x27;escaped&#x27;"
     );
 }

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -40,12 +40,9 @@ struct EscapeTemplate<'a> {
 
 #[test]
 fn test_escape() {
-    let s = EscapeTemplate { name: "<>&\"'/" };
+    let s = EscapeTemplate { name: "<>&\"'" };
 
-    assert_eq!(
-        s.render().unwrap(),
-        "Hello, &lt;&gt;&amp;&quot;&#x27;&#x2f;!"
-    );
+    assert_eq!(s.render().unwrap(), "Hello, &lt;&gt;&amp;&quot;&#x27;!");
 }
 
 #[derive(Template)]


### PR DESCRIPTION
**Reopens and resolves #245 based on new recommendation from OWASP**

This was based off of the OWASP XSS prevention cheat sheet --
https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-rules-summary

However, there isn't really any attack vector based on forward slash alone, and
it's being removed in the next version of that document.

> There is no proof that escaping forward slash will improve
> defense against XSS, if all other special characters are escaped
> properly, but it forces developers to use non-standard implementation of
> the HTML escaping, what increases the risk of the mistake and makes the
> implementation harder.

https://github.com/OWASP/CheatSheetSeries/pull/516