### PR TITLE
Fix code generation for macro calls that store args in variables.

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -717,6 +717,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
 
         let mut names = Buffer::new(0);
         let mut values = Buffer::new(0);
+        let mut is_first_variable = true;
         for (i, arg) in def.args.iter().enumerate() {
             let expr = args.get(i).ok_or_else(|| {
                 CompileError::String(format!("macro '{}' takes more than {} arguments", name, i))
@@ -742,7 +743,9 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
                 // multiple times, e.g. in the case of macro
                 // parameters being used multiple times.
                 _ => {
-                    if i > 0 {
+                    if is_first_variable {
+                        is_first_variable = false
+                    } else {
                         names.write(", ");
                         values.write(", ");
                     }

--- a/testing/templates/nested-macro-args.html
+++ b/testing/templates/nested-macro-args.html
@@ -1,0 +1,9 @@
+{%- macro outer(first) -%}
+{%- call inner(first, "second") -%}
+{%- endmacro -%}
+
+{%- macro inner(first, second) -%}
+{{ first }} {{ second }}
+{%- endmacro -%}
+
+{%- call outer("first") -%}

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -53,3 +53,13 @@ fn test_short_circuit() {
     let t = ShortCircuitTemplate {};
     assert_eq!(t.render().unwrap(), "truetruetruefalsetruetrue");
 }
+
+#[derive(Template)]
+#[template(path = "nested-macro-args.html")]
+struct NestedMacroArgsTemplate {}
+
+#[test]
+fn test_nested_macro_with_args() {
+    let t = NestedMacroArgsTemplate {};
+    assert_eq!(t.render().unwrap(), "first second");
+}


### PR DESCRIPTION
This fixes #498 for me locally. I don't know enough about the codebase to know how to write a good test for this or whether there's a cleaner way to fix it. But I'll be happy to polish this up a bit if you can give me a few pointers.