### PR TITLE
Implement "if let" statement

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -484,29 +484,26 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
             }
 
             let mut arm_size = 0;
-            match *cond {
-                Some(ref expr) => {
-                    if i == 0 {
-                        buf.write("if ");
-                    } else {
-                        buf.dedent()?;
-                        buf.write("} else if ");
-                    }
-                    // The following syntax `*(&(...) as &bool)` is used to
-                    // trigger Rust's automatic dereferencing, to coerce
-                    // e.g. `&&&&&bool` to `bool`. First `&(...) as &bool`
-                    // coerces e.g. `&&&bool` to `&bool`. Then `*(&bool)`
-                    // finally dereferences it to `bool`.
-                    buf.write("*(&(");
-                    let expr_code = self.visit_expr_root(expr)?;
-                    buf.write(&expr_code);
-                    buf.write(") as &bool)");
-                }
-                None => {
+            if let Some(expr) = cond {
+                if i == 0 {
+                    buf.write("if ");
+                } else {
                     buf.dedent()?;
-                    buf.write("} else");
-                    has_else = true;
+                    buf.write("} else if ");
                 }
+                // The following syntax `*(&(...) as &bool)` is used to
+                // trigger Rust's automatic dereferencing, to coerce
+                // e.g. `&&&&&bool` to `bool`. First `&(...) as &bool`
+                // coerces e.g. `&&&bool` to `&bool`. Then `*(&bool)`
+                // finally dereferences it to `bool`.
+                buf.write("*(&(");
+                let expr_code = self.visit_expr_root(expr)?;
+                buf.write(&expr_code);
+                buf.write(") as &bool)");
+            } else {
+                buf.dedent()?;
+                buf.write("} else");
+                has_else = true;
             }
 
             buf.writeln(" {")?;

--- a/testing/templates/if-let-else.html
+++ b/testing/templates/if-let-else.html
@@ -1,0 +1,7 @@
+{%- if !cond -%}
+    !cond
+{%- else if let Ok(ok) = value -%}
+    {{ ok }}
+{%- else if let Err(err) = value -%}
+    {{ err }}
+{%- endif -%}

--- a/testing/templates/if-let-shadowing.html
+++ b/testing/templates/if-let-shadowing.html
@@ -1,0 +1,1 @@
+{% if let Some(text) = text %}{{ text }}{% endif %}

--- a/testing/templates/if-let-struct.html
+++ b/testing/templates/if-let-struct.html
@@ -1,0 +1,1 @@
+{% if let Digits { one, two, three } = digits %}{{ one }} {{ two }} {{ three }}{% endif %}

--- a/testing/templates/if-let.html
+++ b/testing/templates/if-let.html
@@ -1,0 +1,1 @@
+{% if let Some(some_text) = text %}{{ some_text }}{% endif %}

--- a/testing/tests/if_let.rs
+++ b/testing/tests/if_let.rs
@@ -1,0 +1,109 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(path = "if-let.html")]
+struct IfLetTemplate {
+    text: Option<&'static str>,
+}
+
+#[test]
+fn test_if_let() {
+    let s = IfLetTemplate {
+        text: Some("hello"),
+    };
+    assert_eq!(s.render().unwrap(), "hello");
+
+    let t = IfLetTemplate { text: None };
+    assert_eq!(t.render().unwrap(), "");
+}
+
+#[derive(Template)]
+#[template(path = "if-let-shadowing.html")]
+struct IfLetShadowingTemplate {
+    text: Option<&'static str>,
+}
+
+#[test]
+fn test_if_let_shadowing() {
+    let s = IfLetShadowingTemplate {
+        text: Some("hello"),
+    };
+    assert_eq!(s.render().unwrap(), "hello");
+
+    let t = IfLetShadowingTemplate { text: None };
+    assert_eq!(t.render().unwrap(), "");
+}
+
+struct Digits {
+    one: i32,
+    two: i32,
+    three: i32,
+}
+
+#[derive(Template)]
+#[template(path = "if-let-struct.html")]
+struct IfLetStruct {
+    digits: Digits,
+}
+
+#[test]
+fn test_if_let_struct() {
+    let digits = Digits {
+        one: 1,
+        two: 2,
+        three: 3,
+    };
+    let s = IfLetStruct { digits };
+    assert_eq!(s.render().unwrap(), "1 2 3");
+}
+
+#[derive(Template)]
+#[template(path = "if-let-struct.html")]
+struct IfLetStructRef<'a> {
+    digits: &'a Digits,
+}
+
+#[test]
+fn test_if_let_struct_ref() {
+    let digits = Digits {
+        one: 1,
+        two: 2,
+        three: 3,
+    };
+    let s = IfLetStructRef { digits: &digits };
+    assert_eq!(s.render().unwrap(), "1 2 3");
+}
+
+#[derive(Template)]
+#[template(path = "if-let-else.html")]
+struct IfLetElse {
+    cond: bool,
+    value: Result<i32, &'static str>,
+}
+
+#[test]
+fn test_if_let_else() {
+    let s = IfLetElse {
+        cond: false,
+        value: Ok(4711),
+    };
+    assert_eq!(s.render().unwrap(), "!cond");
+
+    let s = IfLetElse {
+        cond: true,
+        value: Ok(4711),
+    };
+    assert_eq!(s.render().unwrap(), "4711");
+
+    let s = IfLetElse {
+        cond: false,
+        value: Err("fail"),
+    };
+    assert_eq!(s.render().unwrap(), "!cond");
+
+    let s = IfLetElse {
+        cond: true,
+        value: Err("fail"),
+    };
+    assert_eq!(s.render().unwrap(), "fail");
+}


### PR DESCRIPTION
This PR implements ``{% if let variant = value %}`` conditions.

The variant can be ``None``, ``Some(foo)``, ``MyStruct { x, y }``,
etc., but nested matching is not implemented. Names are matched by
reference.

The syntax is mostly sugar for

```rs
{% match val %}
    {% when variant %}
        ...
    {% when _ -%}
{% endmatch %}
```

but it can be used in ordinary if-else blocks.