### PR TITLE
Fix and optimize visit_target usage

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1533,7 +1533,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         DisplayWrap::Unwrapped
     }
 
-    fn visit_target(&mut self, buf: &mut Buffer, target: &'a Target<'_>) {
+    fn visit_target(&mut self, buf: &mut Buffer, target: &Target<'a>) {
         match *target {
             Target::Name(name) => {
                 let name = normalize_identifier(name);
@@ -1543,9 +1543,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
             Target::Tuple(ref targets) => {
                 buf.write("(");
                 for name in targets {
-                    let name = normalize_identifier(name);
-                    self.locals.insert_with_default(name);
-                    buf.write(name);
+                    self.visit_target(buf, &Target::Name(name));
                     buf.write(",");
                 }
                 buf.write(")");

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -807,23 +807,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         self.handle_ws(ws);
         self.write_buf_writable(buf)?;
         buf.write("let ");
-        match *var {
-            Target::Name(name) => {
-                let name = normalize_identifier(name);
-                self.locals.insert_with_default(name);
-                buf.write(name);
-            }
-            Target::Tuple(ref targets) => {
-                buf.write("(");
-                for name in targets {
-                    let name = normalize_identifier(name);
-                    self.locals.insert_with_default(name);
-                    buf.write(name);
-                    buf.write(",");
-                }
-                buf.write(")");
-            }
-        }
+        self.visit_target(buf, var);
         buf.writeln(";")
     }
 

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -822,7 +822,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         let mut expr_buf = Buffer::new(0);
         self.visit_expr(&mut expr_buf, val)?;
 
-        match *var {
+        match var {
             Target::Name(name) => {
                 let name = normalize_identifier(name);
                 let meta = self.locals.get(&name).cloned();
@@ -840,7 +840,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
 
                 self.locals.insert(name, LocalMeta::initialized());
             }
-            Target::Tuple(ref targets) => {
+            Target::Tuple(targets) => {
                 let shadowed = targets.iter().any(|name| {
                     let name = normalize_identifier(name);
                     matches!(self.locals.get(&name), Some(meta) if meta.initialized)
@@ -1518,13 +1518,13 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     }
 
     fn visit_target(&mut self, buf: &mut Buffer, target: &Target<'a>) {
-        match *target {
+        match target {
             Target::Name(name) => {
                 let name = normalize_identifier(name);
                 self.locals.insert_with_default(name);
                 buf.write(name);
             }
-            Target::Tuple(ref targets) => {
+            Target::Tuple(targets) => {
                 buf.write("(");
                 for name in targets {
                     self.visit_target(buf, &Target::Name(name));

--- a/testing/tests/loops.rs
+++ b/testing/tests/loops.rs
@@ -214,3 +214,24 @@ fn test_for_vec_attr_range() {
     };
     assert_eq!(t.render().unwrap(), "1 2 3 4 5 6 ");
 }
+
+#[derive(Template)]
+#[template(
+    source = "{% for v in v %}{% let v = v %}{% for v in v.iterable %}{% let v = v %}{{ v }} {% endfor %}{% endfor %}",
+    ext = "txt"
+)]
+struct ForVecAttrSliceShadowingTemplate {
+    v: Vec<ForVecAttrSlice>,
+}
+
+#[test]
+fn test_for_vec_attr_slice_shadowing() {
+    let t = ForVecAttrSliceShadowingTemplate {
+        v: vec![
+            ForVecAttrSlice { iterable: &[1, 2] },
+            ForVecAttrSlice { iterable: &[3, 4] },
+            ForVecAttrSlice { iterable: &[5, 6] },
+        ],
+    };
+    assert_eq!(t.render().unwrap(), "1 2 3 4 5 6 ");
+}


### PR DESCRIPTION
There was a bit of code duplication in generator.rs with respect to the output of targets.

Also there was a bug which caused broken code for

```rs
{% for val in range %}{% set val = "anything" %}{% endfor %}
```

which tried to write to `val` instead of shadowing it.