### PR TITLE
Better error messages using cuts

### DIFF
--- a/testing/tests/ui/typo_in_keyword.rs
+++ b/testing/tests/ui/typo_in_keyword.rs
@@ -1,0 +1,11 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(
+    source = "{%for i in 1..=10%}{{i}}{%endfo%}\n1234567890123456789012345678901234567890",
+    ext = "txt"
+)]
+struct MyTemplate;
+
+fn main() {
+}

--- a/testing/tests/ui/typo_in_keyword.stderr
+++ b/testing/tests/ui/typo_in_keyword.stderr
@@ -1,0 +1,8 @@
+error: problems parsing template source at row 1, column 26 near:
+"endfo%}\n12345678901234567890123456789012"...
+ --> $DIR/typo_in_keyword.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR is not well tested and is more akin to a prove of concept.

The idea it to turn recoverable parsing errors into failures, when there can be no other valid path.

The error location then is used to report the (approximate) row and column. 