### PR TITLE
 Use "target()" to parse "when" block 

### DIFF
--- a/askama_shared/src/heritage.rs
+++ b/askama_shared/src/heritage.rs
@@ -90,7 +90,7 @@ impl<'a> Context<'a> {
                         nested.push(nodes);
                     }
                     Node::Match(_, _, arms, _) => {
-                        for (_, _, _, arm) in arms {
+                        for (_, _, arm) in arms {
                             nested.push(arm);
                         }
                     }

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -442,6 +442,7 @@ fn target(i: &[u8]) -> IResult<&[u8], Target<'_>> {
     // match structs
     let (i, path) = opt(path)(i)?;
     if let Some(path) = path {
+        let (i, _) = opt(ws(tag("with")))(i)?;
         let (i, is_unnamed_struct) = opt_opening_paren(i)?;
         if is_unnamed_struct {
             let (i, targets) = alt((

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -550,7 +550,7 @@ fn parameters(i: &[u8]) -> IResult<&[u8], Vec<&str>> {
 
 fn with_parameters(i: &[u8]) -> IResult<&[u8], MatchParameters<'_>> {
     let (i, (_, value)) = tuple((
-        tag("with"),
+        opt(tag("with")),
         alt((match_simple_parameters, match_named_parameters)),
     ))(i)?;
     Ok((i, value))

--- a/testing/templates/match-option-result-option.html
+++ b/testing/templates/match-option-result-option.html
@@ -1,0 +1,10 @@
+{%- match foo -%}
+    {%- when None -%}
+        nothing
+    {%- when Some(Err(err)) -%}
+        err={{err}}
+    {%- when Some(Ok(None)) -%}
+        num=absent
+    {%- when Some(Ok(Some(num))) -%}
+        num={{num}}
+{%- endmatch -%}

--- a/testing/tests/let_destructoring.rs
+++ b/testing/tests/let_destructoring.rs
@@ -105,3 +105,17 @@ fn test_let_destruct_with_path() {
     };
     assert_eq!(t.render().unwrap(), "hello");
 }
+
+#[derive(Template)]
+#[template(source = "{% let some::path::Struct with (v) = v %}{{v}}", ext = "txt")]
+struct LetDestructoringWithPathAndWithKeyword<'a> {
+    v: some::path::Struct<'a>,
+}
+
+#[test]
+fn test_let_destruct_with_path_and_with_keyword() {
+    let t = LetDestructoringWithPathAndWithKeyword {
+        v: some::path::Struct("hello"),
+    };
+    assert_eq!(t.render().unwrap(), "hello");
+}

--- a/testing/tests/matches.rs
+++ b/testing/tests/matches.rs
@@ -113,3 +113,20 @@ fn test_match_no_whitespace() {
     let s = MatchNoWhitespace { foo: Some(1) };
     assert_eq!(s.render().unwrap(), "1");
 }
+
+#[derive(Template)]
+#[template(
+    source = "{% match foo %}{% when Some(bar) %}{{ bar }}{% when None %}{% endmatch %}",
+    ext = "txt"
+)]
+struct MatchWithoutWithKeyword {
+    foo: Option<usize>,
+}
+
+#[test]
+fn test_match_without_with_keyword() {
+    let s = MatchWithoutWithKeyword { foo: Some(1) };
+    assert_eq!(s.render().unwrap(), "1");
+    let s = MatchWithoutWithKeyword { foo: None };
+    assert_eq!(s.render().unwrap(), "");
+}

--- a/testing/tests/matches.rs
+++ b/testing/tests/matches.rs
@@ -130,3 +130,27 @@ fn test_match_without_with_keyword() {
     let s = MatchWithoutWithKeyword { foo: None };
     assert_eq!(s.render().unwrap(), "");
 }
+
+#[derive(Template)]
+#[template(path = "match-option-result-option.html")]
+struct MatchOptionResultOption {
+    foo: Option<Result<Option<usize>, &'static str>>,
+}
+
+#[test]
+fn test_match_option_result_option() {
+    let s = MatchOptionResultOption { foo: None };
+    assert_eq!(s.render().unwrap(), "nothing");
+    let s = MatchOptionResultOption {
+        foo: Some(Err("fail")),
+    };
+    assert_eq!(s.render().unwrap(), "err=fail");
+    let s = MatchOptionResultOption {
+        foo: Some(Ok(None)),
+    };
+    assert_eq!(s.render().unwrap(), "num=absent");
+    let s = MatchOptionResultOption {
+        foo: Some(Ok(Some(4711))),
+    };
+    assert_eq!(s.render().unwrap(), "num=4711");
+}

--- a/testing/tests/ui/lit_on_assignment_lhs.rs
+++ b/testing/tests/ui/lit_on_assignment_lhs.rs
@@ -1,0 +1,11 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(
+    source = "{%let 7=x%}",
+    ext = "txt"
+)]
+struct MyTemplate;
+
+fn main() {
+}

--- a/testing/tests/ui/lit_on_assignment_lhs.stderr
+++ b/testing/tests/ui/lit_on_assignment_lhs.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> $DIR/lit_on_assignment_lhs.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = help: message: Cannot have literals on the left-hand-side of an assignment.

--- a/testing/tests/vars.rs
+++ b/testing/tests/vars.rs
@@ -105,3 +105,29 @@ fn test_destruct_tuple() {
     };
     assert_eq!(t.render().unwrap(), "wxyz\nwz\nw");
 }
+
+#[derive(Template)]
+#[template(
+    source = "{% let x = 1 %}{% for x in x..=x %}{{ x }}{% endfor %}",
+    ext = "txt"
+)]
+struct DeclRange;
+
+#[test]
+fn test_decl_range() {
+    let t = DeclRange;
+    assert_eq!(t.render().unwrap(), "1");
+}
+
+#[derive(Template)]
+#[template(
+    source = "{% let x %}{% let x = 1 %}{% for x in x..=x %}{{ x }}{% endfor %}",
+    ext = "txt"
+)]
+struct DeclAssignRange;
+
+#[test]
+fn test_decl_assign_range() {
+    let t = DeclAssignRange;
+    assert_eq!(t.render().unwrap(), "1");
+}


### PR DESCRIPTION
`target()` as used in parsing "let" and "if let" implements parsing nested tuples and structs. But it does not implement parsing literals.

The functions `match_variant()` and `with_parameters()` as used in parsing "when" blocks do not implement parsing nested structs, but it implements parsing literals.

This PR combines `match_variant()` and `with_parameters()` into `target()`, so that all `{%when%}` support nested structs, too.