### PR TITLE
Upgrade nom to 6.2.1 (bitvec & funty issue)

### DIFF
--- a/askama_shared/Cargo.toml
+++ b/askama_shared/Cargo.toml
@@ -19,8 +19,7 @@ yaml = ["serde", "serde_yaml"]
 [dependencies]
 askama_escape = { version = "0.10", path = "../askama_escape" }
 humansize = { version = "1.1.0", optional = true }
-funty = "=1.1.0" # Temporary fix for bitvec, remove once fixed. (https://github.com/bitvecto-rs/bitvec/issues/105)
-nom = { version = "6", features = ["std"], default-features = false }
+nom = { version = "6.2.1", features = ["std"], default-features = false } # Gets us a newer version of bitvec https://github.com/Geal/nom/issues/1311#issuecomment-880902973
 num-traits = { version = "0.2.6", optional = true }
 proc-macro2 = "1"
 quote = "1"


### PR DESCRIPTION
More information here https://github.com/djc/askama/issues/522.

I haven't checked the contributing guidelines here if contributors are expected to also send changes to versions, changelogs, etc - but I will follow-up in this PR over the next hours/days.