### PR TITLE
Enable config support in askama_shared build dependency

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["config", "humansize", "num-traits", "urlencode"]
-config = ["askama_shared/config"]
+config = ["askama_derive/config", "askama_shared/config"]
 humansize = ["askama_shared/humansize"]
 urlencode = ["askama_shared/percent-encoding"]
 serde-json = ["askama_shared/json"]

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -14,6 +14,8 @@ edition = "2018"
 proc-macro = true
 
 [features]
+config = ["askama_shared/config"]
+
 actix-web = []
 gotham = []
 iron = []


### PR DESCRIPTION
Fixes using askama with the new Cargo feature resolver and a configuration file.

I have not

* looked into whether the same thing should be done for other features
* tried to find out whether there is a point in enabling the config feature for the runtime dependency on askama_shared
* tried enabling the new feature resolver for askama itself

Documentation for the new feature resolver: https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2