### PR TITLE
Add test case for matching on Option<bool>

### DIFF
--- a/testing/templates/match-opt-bool.html
+++ b/testing/templates/match-opt-bool.html
@@ -1,0 +1,8 @@
+{% match item %}
+{% when Some with (true) %}
+Found Some(true)
+{% when Some with (false) %}
+Found Some(false)
+{% when None %}
+Not Found
+{% endmatch %}

--- a/testing/tests/matches.rs
+++ b/testing/tests/matches.rs
@@ -26,6 +26,24 @@ fn test_match_option() {
     assert_eq!(s.render().unwrap(), "\nNot Found\n");
 }
 
+#[derive(Template)]
+#[template(path = "match-opt-bool.html")]
+struct MatchOptBoolTemplate {
+    item: Option<bool>
+}
+
+#[test]
+fn test_match_option_bool() {
+    let s = MatchOptBoolTemplate { item: Some(true) };
+    assert_eq!(s.render().unwrap(), "\nFound Some(true)\n");
+
+    let s = MatchOptBoolTemplate { item: Some(false) };
+    assert_eq!(s.render().unwrap(), "\nFound Some(false)\n");
+
+    let s = MatchOptBoolTemplate { item: None };
+    assert_eq!(s.render().unwrap(), "\nNot Found\n");
+}
+
 #[test]
 fn test_match_ref_deref() {
     let s = MatchOptRefTemplate { item: &Some("foo") };


### PR DESCRIPTION
This adds a (currently failing) test for `{% match %}`ing on `Option<bool>` with a `Some(true)` pattern. Since https://github.com/djc/askama/commit/268d8250fb0a9cdcbbd760bdf39424ed02fd1920, this emits `Some(r#true)` (matching any `Some` and storing the boolean value into a variable named `true`) which is a bug, as before it emitted `Some(true)` as expected (matching only `Some` where the value is `true`). CC @Kijewski, author of the commit which I think introduced this bug after bisecting.