### PR TITLE
Offload #[template(...)] attribute parsing to `darling` crate

### DIFF
--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -17,6 +17,9 @@ pub fn derive_template(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
     match build_template(&ast) {
         Ok(source) => source.parse().unwrap(),
+        // Use precise span information if available, otherwise fall back to placing
+        // the error at the macro call site.
+        Err(CompileError::Darling(e)) => e.write_errors().into(),
         Err(e) => syn::Error::new(Span::call_site(), e)
             .to_compile_error()
             .into(),

--- a/askama_shared/Cargo.toml
+++ b/askama_shared/Cargo.toml
@@ -18,6 +18,7 @@ yaml = ["serde", "serde_yaml"]
 
 [dependencies]
 askama_escape = { version = "0.10", path = "../askama_escape" }
+darling = "0.13.0"
 humansize = { version = "1.1.0", optional = true }
 nom = "7"
 num-traits = { version = "0.2.6", optional = true }

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -294,6 +294,7 @@ static DEFAULT_ESCAPERS: &[(&[&str], &str)] = &[
 pub enum CompileError {
     Static(&'static str),
     String(String),
+    Darling(darling::Error),
 }
 
 impl fmt::Display for CompileError {
@@ -301,6 +302,7 @@ impl fmt::Display for CompileError {
         match self {
             CompileError::Static(s) => write!(fmt, "{}", s),
             CompileError::String(s) => write!(fmt, "{}", s),
+            CompileError::Darling(e) => write!(fmt, "{}", e),
         }
     }
 }
@@ -314,6 +316,12 @@ impl From<&'static str> for CompileError {
 impl From<String> for CompileError {
     fn from(s: String) -> Self {
         CompileError::String(s)
+    }
+}
+
+impl From<darling::Error> for CompileError {
+    fn from(e: darling::Error) -> Self {
+        CompileError::Darling(e)
     }
 }
 


### PR DESCRIPTION
`darling` is "serde for the AST." Its main advantages are:

* Errors are now more-precisely attached to the input AST
* Remove boilerplate for attribute parsing

This PR is a fairly minimal change; if this is directionally acceptable, there are a couple additions that a future PR could make:

- Using `#[darling(supports(struct_named))]` to only allow derivation on named structs
- Retaining span information in `TemplateOptions` to make the lookup failures (e.g. syntax, escaper) point to the correct input span

Disclaimer: I'm the author and maintainer of `darling`.