### PR TITLE
 Added support for optional escaper for escape filter

### DIFF
--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -106,15 +106,6 @@ where
     Ok(MarkupDisplay::new_unsafe(v, e))
 }
 
-/// Alias for the `escape()` filter
-pub fn e<E, T>(e: E, v: T) -> Result<MarkupDisplay<E, T>>
-where
-    E: Escaper,
-    T: fmt::Display,
-{
-    escape(e, v)
-}
-
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
 pub fn filesizeformat<B: FileSize>(b: &B) -> Result<String> {

--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -73,6 +73,28 @@ Output:
 Escape &lt;&gt;&amp;
 ```
 
+Optionally, it is possible to specify and override which escaper is used. Consider a template where the escaper is configured as [`escape = "none"`]. However, somewhere escaping using the HTML escaper is desired. Then it is possible to override and use the HTML escaper like this:
+
+```jinja
+{{ "Don't Escape <>&"|escape }}
+{{ "Don't Escape <>&"|e }}
+
+{{ "Escape <>&"|escape("html") }}
+{{ "Escape <>&"|e("html") }}
+```
+
+Output:
+
+```text
+Don't Escape <>&
+Don't Escape <>&
+
+Escape &lt;&gt;&amp;
+Escape &lt;&gt;&amp;
+```
+
+[`escape = "none"`]: creating_templates.html#the-template-attribute
+
 ### filesizeformat
 
 Returns adequate string representation (in KB, ..) of number of bytes:

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -27,6 +27,54 @@ fn filter_escape() {
 }
 
 #[derive(Template)]
+#[template(
+    source = "{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"none\") }}
+{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"html\") }}
+{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape }}
+{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\" }}
+",
+    ext = "txt",
+    escape = "none"
+)]
+struct OptEscaperNoneTemplate;
+
+#[test]
+fn filter_opt_escaper_none() {
+    let t = OptEscaperNoneTemplate;
+    assert_eq!(
+        t.render().unwrap(),
+        r#"<h1 class="title">Foo Bar</h1>
+&lt;h1 class=&quot;title&quot;&gt;Foo Bar&lt;/h1&gt;
+<h1 class="title">Foo Bar</h1>
+<h1 class="title">Foo Bar</h1>"#
+    );
+}
+
+#[derive(Template)]
+#[template(
+    source = "{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"none\") }}
+{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"html\") }}
+{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape }}
+{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\" }}
+",
+    ext = "txt",
+    escape = "html"
+)]
+struct OptEscaperHtmlTemplate;
+
+#[test]
+fn filter_opt_escaper_html() {
+    let t = OptEscaperHtmlTemplate;
+    assert_eq!(
+        t.render().unwrap(),
+        r#"<h1 class="title">Foo Bar</h1>
+&lt;h1 class=&quot;title&quot;&gt;Foo Bar&lt;/h1&gt;
+&lt;h1 class=&quot;title&quot;&gt;Foo Bar&lt;/h1&gt;
+&lt;h1 class=&quot;title&quot;&gt;Foo Bar&lt;/h1&gt;"#
+    );
+}
+
+#[derive(Template)]
 #[template(path = "format.html", escape = "none")]
 struct FormatTemplate<'a> {
     var: &'a str,


### PR DESCRIPTION
Resolves #556

- Added support for optional escaper arg for `escape filter`, e.g. `{{ foo|escape("html") }}` and `{{ foo|e("html") }}`
- Added tests
- Updated book

Additionally, I removed `fn e()`, which is technically a breaking change, so I added a `pub use escape as e;`. Maybe it's _safe_ to assume _nobody_ depends on `askama_shared` directly. Only to `use askama_shared::filters::e;`, but I'll let you decide on that, then I'll remove it if needed.
