### PR TITLE
Add block-based partials

### DIFF
--- a/askama_shared/src/input.rs
+++ b/askama_shared/src/input.rs
@@ -15,6 +15,7 @@ pub struct TemplateInput<'a> {
     pub ext: Option<String>,
     pub parent: Option<&'a syn::Type>,
     pub path: PathBuf,
+    pub block: Option<String>,
 }
 
 impl<'a> TemplateInput<'a> {
@@ -52,6 +53,7 @@ impl<'a> TemplateInput<'a> {
         let mut escaping = None;
         let mut ext = None;
         let mut syntax = None;
+        let mut block = None;
         for item in meta_list.nested {
             let pair = match item {
                 syn::NestedMeta::Meta(syn::Meta::NameValue(ref pair)) => pair,
@@ -105,6 +107,12 @@ impl<'a> TemplateInput<'a> {
                     syntax = Some(s.value())
                 } else {
                     return Err("syntax value must be string literal".into());
+                }
+            } else if pair.path.is_ident("block") {
+                if let syn::Lit::Str(ref s) = pair.lit {
+                    block = Some(s.value());
+                } else {
+                    return Err("block value must be string literal".into());
                 }
             } else {
                 return Err(format!(
@@ -189,6 +197,7 @@ impl<'a> TemplateInput<'a> {
             ext,
             parent,
             path,
+            block,
         })
     }
 

--- a/book/src/creating_templates.md
+++ b/book/src/creating_templates.md
@@ -66,6 +66,14 @@ recognized:
       name: &'a str,
   }
   ```
+* `block` (as `block = "section_a"`): extracts a named block (a "partial")
+  from the original template source and uses only the contents of that
+  block in the final template.
+  ```rust
+  #[derive(Template)]
+  #[template(path = "hello.html", block = "greeting")]
+  struct HelloPartial<'a> { ... }
+  ```
 * `print` (as `print = "code"`): enable debugging by printing nothing
   (`none`), the parsed syntax tree (`ast`), the generated code (`code`)
   or `all` for both. The requested data will be printed to stdout at

--- a/testing/templates/partials.html
+++ b/testing/templates/partials.html
@@ -1,0 +1,20 @@
+<div>
+    {% block first -%}
+    <div>First section: {{ first }}</div>
+    {%- endblock %}
+
+    {% block second -%}
+    <div>
+        {% block second_a -%}
+        <span>Second section, subsection A: {{ second_a }}</span>
+        {%- endblock %}
+        {% block second_b -%}
+        <span>Second section, subsection B: {{ second_b }}</span>
+        {%- endblock %}
+    </div>
+    {%- endblock %}
+
+    {% block third -%}
+    <div>Third section: {{ third }}</div>
+    {%- endblock %}
+</div>

--- a/testing/tests/partials.rs
+++ b/testing/tests/partials.rs
@@ -1,0 +1,152 @@
+use askama::Template;
+
+// Partials let us render a portion of a larger template without needing
+// to extract those portions into their own files (and then using `{%
+// include ... %}` to bring them back into the parent template). The
+// normal use of a partial is to first render the entire template, then
+// render partials as the application data changes, sending just those
+// partial renderings to the client in order to update targeted portions
+// of the UI.
+//
+// First, we show that a template containing block definitions can be
+// rendered just like normal:
+#[derive(Template)]
+#[template(path = "partials.html")]
+struct AllSectionTemplate<'a> {
+    first: &'a str,
+    second_a: &'a str,
+    second_b: &'a str,
+    third: &'a str,
+}
+
+#[test]
+fn test_all_sections() {
+    let t = AllSectionTemplate {
+        first: "1",
+        second_a: "2A",
+        second_b: "2B",
+        third: "3",
+    };
+    assert_eq!(
+        t.render().unwrap(),
+        "<div>
+    <div>First section: 1</div>
+
+    <div>
+        <span>Second section, subsection A: 2A</span>
+        <span>Second section, subsection B: 2B</span>
+    </div>
+
+    <div>Third section: 3</div>
+</div>"
+    );
+}
+
+// Then we can create a template that focuses on a specific block and
+// render just that partial content (note that we only need to include
+// the fields in the template struct that are actually used by this
+// partial):
+#[derive(Template)]
+#[template(path = "partials.html", block = "first")]
+struct FirstPartial<'a> {
+    first: &'a str,
+}
+
+#[test]
+fn test_first_partial() {
+    let t = FirstPartial { first: "One" };
+    assert_eq!(
+        t.render().unwrap(),
+        "
+    <div>First section: One</div>"
+    );
+}
+
+// Partials can target a block with nested blocks:
+#[derive(Template)]
+#[template(path = "partials.html", block = "second")]
+struct SecondPartial<'a> {
+    second_a: &'a str,
+    second_b: &'a str,
+}
+
+#[test]
+fn test_second_partial() {
+    let t = SecondPartial {
+        second_a: "Two A",
+        second_b: "Or not two A?",
+    };
+    assert_eq!(
+        t.render().unwrap(),
+        "
+    <div>
+        <span>Second section, subsection A: Two A</span>
+        <span>Second section, subsection B: Or not two A?</span>
+    </div>"
+    );
+}
+
+// ...or partials can target a deeply-nested block:
+#[derive(Template)]
+#[template(path = "partials.html", block = "second_b")]
+struct SecondBPartial<'a> {
+    second_b: &'a str,
+}
+
+#[test]
+fn test_second_b_partial() {
+    let t = SecondBPartial { second_b: "Two B" };
+    assert_eq!(
+        t.render().unwrap(),
+        "
+        <span>Second section, subsection B: Two B</span>"
+    );
+}
+
+// Note that while you *can* target a block in a child template, this is
+// the less common way to use a partial *and* requires that the child
+// specifically reference the block. So this works, because `child.html`
+// overrides the `content` block:
+#[derive(Template)]
+#[template(path = "child.html", block = "content")]
+struct ChildContentPartial<'a> {
+    title: &'a str,
+}
+
+#[test]
+fn test_child_content_partial() {
+    let t = ChildContentPartial { title: "Bar" };
+    assert_eq!(t.render().unwrap(), "(Bar) Content goes here");
+}
+
+// ...but this does *not* work, because the `foo` block is only
+// mentioned in the `base.html` template and so cannot be targeted by
+// the `block` attribute that locates a partial:
+//
+// #[derive(Template)]
+// #[template(path = "child.html", block = "foo")]
+// struct ChildInheritsFooPartial<'a> {
+//     title: &'a str,
+// }
+//
+// #[test]
+// fn test_child_inherits_foo_partial() {
+//     let t = ChildFooPartial { title: "Bar" };
+//     assert_eq!(t.render().unwrap(), "Foo");
+// }
+
+// This test, however, does work, because the child explicitly names the
+// `foo` block and so we can refer to it in a partial.
+#[derive(Template)]
+#[template(
+    source = "{% extends \"base.html\" %}{% block foo %}FooChild{% endblock %}",
+    ext = "html",
+    block = "foo"
+)]
+struct ChildSpecifiesFooPartial {}
+
+#[test]
+fn test_child_specifies_foo_partial() {
+    let t = ChildSpecifiesFooPartial {};
+    assert_eq!(t.render().unwrap(), "FooChild");
+}


### PR DESCRIPTION
Adds support for rendering partial templates from existing templates without requiring that the template be split into multiple, `include`d files. This feature is enabled using the new `block` sub-attribute on the `template()` attribute, which causes the generated template to only include the named block (and its contents). This works especially well with client-side frameworks like [htmx](https://htmx.org/) that encourage returning only changed subsections of a previous HTML file.

Prior art that I reviewed when implementing this feature:

- htmx tweet proposing a feature like this in server-side templating languages: <https://twitter.com/htmx_org/status/1419657468301348866>
- [DjPj](https://pypi.org/project/DjPj/) uses the `block` and `endblock` tags to select partials.
- Django Mako Plus also [provides support for partials](https://doconix.github.io/django-mako-plus/topics_partial_templates.html) using its version of the `block` tags.

I tried to keep this change as simple as possible and implemented the feature by modifying the generator to select only the named block's nodes when the partial feature is in use. I believe that this ensures that the entire rest of the generator/handler functions see only those nodes, just as if they were the only contents in the template source.

I chose to name the new `template()` attribute `block` since that is what is being targeted by the generator, but I think that the name `partial` might also be a good choice.

I am open to any and all suggestions to improve this feature and welcome any comments that you might have. Thank you for taking the time to review this feature/feature request!