### PR TITLE
 Implement error propagation expression: `?`

### DIFF
--- a/askama_shared/src/error.rs
+++ b/askama_shared/src/error.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Display};
+use std::marker::PhantomData;
 
-pub type Result<I> = ::std::result::Result<I, Error>;
+pub type Result<I, E = Error> = ::std::result::Result<I, E>;
 
 /// askama error type
 ///
@@ -28,6 +29,8 @@ pub enum Error {
     /// formatting error
     Fmt(fmt::Error),
 
+    Custom(Box<dyn std::error::Error + Send + Sync>),
+
     /// json conversion error
     #[cfg(feature = "serde_json")]
     Json(::serde_json::Error),
@@ -41,6 +44,7 @@ impl std::error::Error for Error {
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::Fmt(ref err) => err.source(),
+            Error::Custom(ref err) => Some(err.as_ref()),
             #[cfg(feature = "serde_json")]
             Error::Json(ref err) => err.source(),
             #[cfg(feature = "serde_yaml")]
@@ -51,12 +55,13 @@ impl std::error::Error for Error {
 
 impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Error::Fmt(ref err) => write!(formatter, "formatting error: {}", err),
+        match self {
+            Error::Fmt(err) => write!(formatter, "formatting error: {}", err),
+            Error::Custom(err) => write!(formatter, "{}", err),
             #[cfg(feature = "serde_json")]
-            Error::Json(ref err) => write!(formatter, "json conversion error: {}", err),
+            Error::Json(err) => write!(formatter, "json conversion error: {}", err),
             #[cfg(feature = "serde_yaml")]
-            Error::Yaml(ref err) => write!(formatter, "yaml conversion error: {}", err),
+            Error::Yaml(err) => write!(formatter, "yaml conversion error: {}", err),
         }
     }
 }
@@ -79,6 +84,70 @@ impl From<::serde_yaml::Error> for Error {
     fn from(err: ::serde_yaml::Error) -> Self {
         Error::Yaml(err)
     }
+}
+
+#[doc(hidden)]
+pub struct CustomErrorTag;
+
+#[doc(hidden)]
+pub struct CommonErrorTag;
+
+#[doc(hidden)]
+pub trait CustomErrorKind {
+    #[inline]
+    fn askama_error_kind(&self) -> CustomErrorTag {
+        CustomErrorTag
+    }
+}
+
+#[doc(hidden)]
+pub trait CommonErrorKind {
+    #[inline]
+    fn askama_error_kind(&self) -> CommonErrorTag {
+        CommonErrorTag
+    }
+}
+
+impl CustomErrorTag {
+    #[inline]
+    pub fn convert(self, err: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Error {
+        Error::Custom(err.into())
+    }
+}
+
+impl CommonErrorTag {
+    #[inline]
+    pub fn convert(self, error: impl Into<Error>) -> Error {
+        error.into()
+    }
+}
+
+#[doc(hidden)]
+pub struct ErrorKindWrapper<E>(PhantomData<fn() -> *const E>);
+
+#[doc(hidden)]
+#[inline]
+pub fn new_error_kind_wrapper<E>(err: E) -> (ErrorKindWrapper<E>, E) {
+    let wrapper = ErrorKindWrapper(PhantomData);
+    (wrapper, err)
+}
+
+impl<T: Into<Box<dyn std::error::Error + Send + Sync>>> CustomErrorKind for &ErrorKindWrapper<T> {}
+
+impl<T: Into<Error>> CommonErrorKind for ErrorKindWrapper<T> {}
+
+#[macro_export]
+macro_rules! into_error {
+    ($value:expr $(,)?) => {
+        match $value {
+            ::core::result::Result::Ok(value) => value,
+            ::core::result::Result::Err(err) => {
+                use ::askama::shared::error::{CommonErrorKind, CustomErrorKind};
+                let (wrapper, err) = ::askama::shared::error::new_error_kind_wrapper(err);
+                return ::askama::shared::Result::Err((&wrapper).askama_error_kind().convert(err));
+            }
+        }
+    };
 }
 
 #[cfg(test)]

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1069,9 +1069,9 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         buf: &mut Buffer,
         expr: &Expr<'_>,
     ) -> Result<DisplayWrap, CompileError> {
-        buf.write("::askama::shared::into_error!(");
+        buf.write("::core::result::Result::map_err(");
         self.visit_expr(buf, expr)?;
-        buf.write(")");
+        buf.write(", |err| ::askama::shared::Error::Custom(::core::convert::Into::into(err)))?");
         Ok(DisplayWrap::Unwrapped)
     }
 

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1060,7 +1060,19 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
             Expr::Group(ref inner) => self.visit_group(buf, inner)?,
             Expr::Call(ref obj, ref args) => self.visit_call(buf, obj, args)?,
             Expr::RustMacro(name, args) => self.visit_rust_macro(buf, name, args),
+            Expr::Try(ref expr) => self.visit_try(buf, expr.as_ref())?,
         })
+    }
+
+    fn visit_try(
+        &mut self,
+        buf: &mut Buffer,
+        expr: &Expr<'_>,
+    ) -> Result<DisplayWrap, CompileError> {
+        buf.write("::askama::shared::into_error!(");
+        self.visit_expr(buf, expr)?;
+        buf.write(")");
+        Ok(DisplayWrap::Unwrapped)
     }
 
     fn visit_rust_macro(&mut self, buf: &mut Buffer, name: &str, args: &str) -> DisplayWrap {

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -14,8 +14,7 @@ use serde::Deserialize;
 pub use crate::input::extension_to_mime_type;
 pub use askama_escape::MarkupDisplay;
 
-#[doc(hidden)]
-pub mod error;
+mod error;
 pub use crate::error::{Error, Result};
 pub mod filters;
 #[doc(hidden)]

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -14,7 +14,8 @@ use serde::Deserialize;
 pub use crate::input::extension_to_mime_type;
 pub use askama_escape::MarkupDisplay;
 
-mod error;
+#[doc(hidden)]
+pub mod error;
 pub use crate::error::{Error, Result};
 pub mod filters;
 #[doc(hidden)]

--- a/testing/tests/try.rs
+++ b/testing/tests/try.rs
@@ -1,0 +1,61 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(source = "{% let v = self.parse()? %}{{s}}={{v}}", ext = "txt")]
+struct IntParserTemplate<'a> {
+    s: &'a str,
+}
+
+impl IntParserTemplate<'_> {
+    fn parse(&self) -> Result<i32, std::num::ParseIntError> {
+        self.s.parse()
+    }
+}
+
+#[test]
+fn test_int_parser() {
+    let template = IntParserTemplate { s: "💯" };
+    assert!(matches!(template.render(), Err(askama::Error::Custom(_))));
+
+    let template = IntParserTemplate { s: "100" };
+    assert_eq!(template.render().unwrap(), "100=100");
+}
+
+#[derive(Template)]
+#[template(source = "{{ value()? }}", ext = "txt")]
+struct FailFmt {
+    value: fn() -> Result<&'static str, std::fmt::Error>,
+}
+
+#[test]
+fn fail_fmt() {
+    let template = FailFmt {
+        value: || Err(std::fmt::Error),
+    };
+    assert!(matches!(template.render(), Err(askama::Error::Fmt(_))));
+
+    let template = FailFmt {
+        value: || Ok("hello world"),
+    };
+    assert_eq!(template.render().unwrap(), "hello world");
+}
+
+#[derive(Template)]
+#[template(source = "{{ value()? }}", ext = "txt")]
+struct FailStr {
+    value: fn() -> Result<&'static str, &'static str>,
+}
+
+#[test]
+fn fail_str() {
+    let template = FailStr {
+        value: || Err("FAIL"),
+    };
+    assert!(matches!(template.render(), Err(askama::Error::Custom(_))));
+    assert_eq!(format!("{}", &template.render().unwrap_err()), "FAIL");
+
+    let template = FailStr {
+        value: || Ok("hello world"),
+    };
+    assert_eq!(template.render().unwrap(), "hello world");
+}

--- a/testing/tests/try.rs
+++ b/testing/tests/try.rs
@@ -16,6 +16,10 @@ impl IntParserTemplate<'_> {
 fn test_int_parser() {
     let template = IntParserTemplate { s: "💯" };
     assert!(matches!(template.render(), Err(askama::Error::Custom(_))));
+    assert_eq!(
+        format!("{}", &template.render().unwrap_err()),
+        "invalid digit found in string"
+    );
 
     let template = IntParserTemplate { s: "100" };
     assert_eq!(template.render().unwrap(), "100=100");
@@ -32,7 +36,11 @@ fn fail_fmt() {
     let template = FailFmt {
         value: || Err(std::fmt::Error),
     };
-    assert!(matches!(template.render(), Err(askama::Error::Fmt(_))));
+    assert!(matches!(template.render(), Err(askama::Error::Custom(_))));
+    assert_eq!(
+        format!("{}", &template.render().unwrap_err()),
+        format!("{}", std::fmt::Error)
+    );
 
     let template = FailFmt {
         value: || Ok("hello world"),


### PR DESCRIPTION
This PR consists of ~three~ ~two~ a change~s~:

* ~Right now almost every expression needs to be parsed twice: `expr_any()` first parses the left-hand side of a range expression, and if no `..` or `..=` was found the left-hand expression is parsed again, this time as the result of the function. This diff removes the second parsing step by first looking for `.. (opt rhs)`, then for `lhs .. (opt rhs)`.~
* ~Instead of having `Expr::VarCall`, `Expr::PathCall` and `Expr::MethodCall`, this diff unifies the handling of calls by removed the former three variants, and introducing `Expr::Call`. This makes parsing postfix operators easier.~
* This change allows using the operator `?` in askama expressions. It works like the same operator in Rust: if a `Result` is `Ok`, it is unwrapped. If it is an error, then the `render()` method fails with this error value.