### PR TITLE
Add more warnings

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -59,16 +59,9 @@
 //!   in the configuration file. The default syntax , "default",  is the one
 //!   provided by Askama.
 
-#![allow(unused_imports)]
 #![deny(elided_lifetimes_in_paths)]
 
-#[macro_use]
-extern crate askama_derive;
 pub use askama_shared as shared;
-
-use std::fs::{self, DirEntry};
-use std::io;
-use std::path::Path;
 
 pub use askama_escape::{Html, Text};
 

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -59,6 +59,7 @@
 //!   in the configuration file. The default syntax , "default",  is the one
 //!   provided by Askama.
 
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -60,6 +60,7 @@
 //!   provided by Askama.
 
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 pub use askama_shared as shared;
 

--- a/askama_actix/src/lib.rs
+++ b/askama_actix/src/lib.rs
@@ -2,11 +2,9 @@
 
 use actix_web::body::BoxBody;
 use actix_web::http::StatusCode;
-use actix_web::HttpResponseBuilder;
+use actix_web::{HttpResponse, HttpResponseBuilder, ResponseError};
 use askama::mime::extension_to_mime_type;
 pub use askama::*;
-
-use actix_web::HttpResponse;
 
 pub trait TemplateToResponse {
     fn to_response(&self) -> HttpResponse<BoxBody>;

--- a/askama_actix/src/lib.rs
+++ b/askama_actix/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_actix/src/lib.rs
+++ b/askama_actix/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 use std::fmt;
 

--- a/askama_actix/src/lib.rs
+++ b/askama_actix/src/lib.rs
@@ -1,10 +1,31 @@
 #![deny(elided_lifetimes_in_paths)]
 
+use std::fmt;
+
 use actix_web::body::BoxBody;
 use actix_web::http::StatusCode;
 use actix_web::{HttpResponse, HttpResponseBuilder, ResponseError};
 use askama::mime::extension_to_mime_type;
 pub use askama::*;
+
+/// Newtype to let askama::Error implement actix_web::ResponseError.
+struct ActixError(Error);
+
+impl fmt::Debug for ActixError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Error as fmt::Debug>::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for ActixError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Error as fmt::Display>::fmt(&self.0, f)
+    }
+}
+
+impl ResponseError for ActixError {}
 
 pub trait TemplateToResponse {
     fn to_response(&self) -> HttpResponse<BoxBody>;
@@ -19,9 +40,7 @@ impl<T: askama::Template> TemplateToResponse for T {
                     .content_type(ctype)
                     .body(buffer)
             }
-            Err(err) => {
-                HttpResponse::from_error(Box::new(err) as Box<dyn std::error::Error + 'static>)
-            }
+            Err(err) => HttpResponse::from_error(ActixError(err)),
         }
     }
 }

--- a/askama_axum/src/lib.rs
+++ b/askama_axum/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_axum/src/lib.rs
+++ b/askama_axum/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 pub use askama::*;
 use axum_core::body;

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 use askama_shared::heritage::{Context, Heritage};
 use askama_shared::input::{Print, Source, TemplateInput};

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -7,6 +7,7 @@ extern crate std;
 use core::fmt::{self, Display, Formatter, Write};
 use core::str;
 
+#[derive(Debug)]
 pub struct MarkupDisplay<E, T>
 where
     E: Escaper,
@@ -65,6 +66,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct EscapeWriter<'a, E, W> {
     fmt: W,
     escaper: &'a E,
@@ -87,6 +89,7 @@ where
     Escaped { string, escaper }
 }
 
+#[derive(Debug)]
 pub struct Escaped<'a, E>
 where
     E: Escaper,

--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 #[cfg(test)]
 extern crate std;

--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -72,7 +72,7 @@ pub struct EscapeWriter<'a, E, W> {
     escaper: &'a E,
 }
 
-impl<'a, E, W> Write for EscapeWriter<'a, E, W>
+impl<E, W> Write for EscapeWriter<'_, E, W>
 where
     W: Write,
     E: Escaper,
@@ -98,7 +98,7 @@ where
     escaper: E,
 }
 
-impl<'a, E> Display for Escaped<'a, E>
+impl<E> Display for Escaped<'_, E>
 where
     E: Escaper,
 {

--- a/askama_gotham/src/lib.rs
+++ b/askama_gotham/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 pub use askama::*;
 

--- a/askama_gotham/src/lib.rs
+++ b/askama_gotham/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_mendes/src/lib.rs
+++ b/askama_mendes/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_mendes/src/lib.rs
+++ b/askama_mendes/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 use std::convert::TryFrom;
 

--- a/askama_rocket/src/lib.rs
+++ b/askama_rocket/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_rocket/src/lib.rs
+++ b/askama_rocket/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 use std::io::Cursor;
 

--- a/askama_shared/src/filters/mod.rs
+++ b/askama_shared/src/filters/mod.rs
@@ -570,16 +570,10 @@ mod tests {
         assert_eq!(join(empty.iter(), ", ").unwrap(), "");
 
         let input: Vec<String> = vec!["foo".into(), "bar".into(), "bazz".into()];
-        assert_eq!(
-            join((&input).iter(), ":".to_string()).unwrap(),
-            "foo:bar:bazz"
-        );
         assert_eq!(join(input.iter(), ":").unwrap(), "foo:bar:bazz");
-        assert_eq!(join(input.iter(), ":".to_string()).unwrap(), "foo:bar:bazz");
 
         let input: &[String] = &["foo".into(), "bar".into()];
         assert_eq!(join(input.iter(), ":").unwrap(), "foo:bar");
-        assert_eq!(join(input.iter(), ":".to_string()).unwrap(), "foo:bar");
 
         let real: String = "blah".into();
         let input: Vec<&str> = vec![&real];

--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1680,7 +1680,7 @@ impl LocalMeta {
 // type SetChain<'a, T> = MapChain<'a, T, ()>;
 
 #[derive(Debug)]
-struct MapChain<'a, K: 'a, V: 'a>
+struct MapChain<'a, K, V>
 where
     K: cmp::Eq + hash::Hash,
 {

--- a/askama_shared/src/helpers/mod.rs
+++ b/askama_shared/src/helpers/mod.rs
@@ -1,5 +1,4 @@
-use std::iter::Enumerate;
-use std::iter::Peekable;
+use std::iter::{Enumerate, Peekable};
 
 pub struct TemplateLoop<I>
 where

--- a/askama_shared/src/heritage.rs
+++ b/askama_shared/src/heritage.rs
@@ -9,7 +9,7 @@ pub struct Heritage<'a> {
     pub blocks: BlockAncestry<'a>,
 }
 
-impl<'a> Heritage<'a> {
+impl Heritage<'_> {
     pub fn new<'n>(
         mut ctx: &'n Context<'n>,
         contexts: &'n HashMap<&'n PathBuf, Context<'n>>,
@@ -41,7 +41,7 @@ pub struct Context<'a> {
     pub imports: HashMap<&'a str, PathBuf>,
 }
 
-impl<'a> Context<'a> {
+impl Context<'_> {
     pub fn new<'n>(
         config: &Config<'_>,
         path: &Path,

--- a/askama_shared/src/input.rs
+++ b/askama_shared/src/input.rs
@@ -17,7 +17,7 @@ pub struct TemplateInput<'a> {
     pub path: PathBuf,
 }
 
-impl<'a> TemplateInput<'a> {
+impl TemplateInput<'_> {
     /// Extract the template metadata from the `DeriveInput` structure. This
     /// mostly recovers the data for the `TemplateInput` fields from the
     /// `template()` attribute list fields; it also finds the of the `_parent`

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "cargo-clippy", allow(unused_parens))]
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(unused_parens))]
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 use std::collections::{BTreeMap, HashSet};
 use std::convert::TryFrom;

--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -32,7 +32,7 @@ pub struct Config<'a> {
     pub escapers: Vec<(HashSet<String>, String)>,
 }
 
-impl<'a> Config<'a> {
+impl Config<'_> {
     pub fn new(s: &str) -> std::result::Result<Config<'_>, CompileError> {
         let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
         let default_dirs = vec![root.join("templates")];
@@ -138,7 +138,7 @@ pub struct Syntax<'a> {
     pub comment_end: &'a str,
 }
 
-impl<'a> Default for Syntax<'a> {
+impl Default for Syntax<'_> {
     fn default() -> Self {
         Self {
             block_start: "{%",
@@ -198,7 +198,7 @@ struct RawConfig<'d> {
     escaper: Option<Vec<RawEscaper<'d>>>,
 }
 
-impl<'d> RawConfig<'d> {
+impl RawConfig<'_> {
     #[cfg(feature = "config")]
     fn from_toml_str(s: &str) -> std::result::Result<RawConfig<'_>, CompileError> {
         toml::from_str(s).map_err(|e| {

--- a/askama_shared/src/parser.rs
+++ b/askama_shared/src/parser.rs
@@ -617,7 +617,7 @@ macro_rules! expr_prec_layer {
         fn $name(i: &str) -> IResult<&str, Expr<'_>> {
             let (i, left) = $inner(i)?;
             let (i, right) = many0(pair(
-                ws(alt(($( tag($op) ),*,))),
+                ws(alt(($( tag($op) ),+,))),
                 $inner,
             ))(i)?;
             Ok((

--- a/askama_tide/src/lib.rs
+++ b/askama_tide/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_tide/src/lib.rs
+++ b/askama_tide/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 pub use askama;
 pub use tide;

--- a/askama_warp/src/lib.rs
+++ b/askama_warp/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_warp/src/lib.rs
+++ b/askama_warp/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
 
 pub use askama::*;
 pub use warp;


### PR DESCRIPTION
Might be overkill, but it can aid preventing programming errors.

I was not able to add `#![forbid(unsafe_code)]` to askama_escape without
a 15% performance drop, so I omitted it.