### PR TITLE
Basic skeleton for a multilinual actix-askama site

### DIFF
--- a/examples/basic-actix-askama-multilingual-site/Cargo.toml
+++ b/examples/basic-actix-askama-multilingual-site/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "basic-actix-askama-multilingual-page"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+actix-web = "4.0.0-beta.19"
+askama = "0.11.0"
+tokio = "1"

--- a/examples/basic-actix-askama-multilingual-site/src/main.rs
+++ b/examples/basic-actix-askama-multilingual-site/src/main.rs
@@ -1,0 +1,113 @@
+//use actix_files as fs;
+use actix_web::{http, middleware, web, App, HttpRequest, HttpResponse, HttpServer, Result};
+use askama::Template;
+
+#[derive(Template)]
+#[template(path = "home/home-en.html")]
+struct HomeEn<'a> {
+    lang: &'a str,
+    title: &'a str,
+    page: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "home/home-it.html")]
+struct HomeIt<'a> {
+    lang: &'a str,
+    title: &'a str,
+    page: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "about/about-en.html")]
+struct AboutEn<'a> {
+    lang: &'a str,
+    title: &'a str,
+    page: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "about/about-it.html")]
+struct AboutIt<'a> {
+    lang: &'a str,
+    title: &'a str,
+    page: &'a str,
+}
+
+async fn index() -> Result<HttpResponse> {
+    Ok(HttpResponse::TemporaryRedirect()
+        .insert_header((http::header::LOCATION, "/en"))
+        .finish())
+}
+
+async fn home(req: HttpRequest) -> Result<HttpResponse> {
+    let lang: String = req.match_info().get("lang").unwrap().parse().unwrap();
+    let s = match lang.as_str() {
+        "en" => HomeEn {
+            lang: &lang,
+            title: &format!("Home-{}", &lang),
+            page: &"home".to_string(),
+        }
+        .render()
+        .unwrap(),
+        "it" => HomeIt {
+            lang: &lang,
+            title: &format!("Home-{}", &lang),
+            page: &"home".to_string(),
+        }
+        .render()
+        .unwrap(),
+        _ => "".to_string(),
+    };
+    if s == "" {
+        Ok(HttpResponse::TemporaryRedirect()
+            .insert_header((http::header::LOCATION, "/en"))
+            .finish())
+    } else {
+        Ok(HttpResponse::Ok().content_type("text/html").body(s))
+    }
+}
+
+async fn about(req: HttpRequest) -> Result<HttpResponse> {
+    let lang: String = req.match_info().get("lang").unwrap().parse().unwrap();
+    let s = match lang.as_str() {
+        "en" => AboutEn {
+            lang: &lang,
+            title: &format!("About-{}", &lang),
+            page: &"about".to_string(),
+        }
+        .render()
+        .unwrap(),
+        "it" => AboutIt {
+            lang: &lang,
+            title: &format!("About-{}", &lang),
+            page: &"about".to_string(),
+        }
+        .render()
+        .unwrap(),
+        _ => "".to_string(),
+    };
+    if s == "" {
+        Ok(HttpResponse::TemporaryRedirect()
+            .insert_header((http::header::LOCATION, "/en"))
+            .finish())
+    } else {
+        Ok(HttpResponse::Ok().content_type("text/html").body(s))
+    }
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    // start http server
+    HttpServer::new(move || {
+        App::new()
+            .wrap(middleware::Logger::default())
+            //.service(fs::Files::new("/static", "static"))
+            .service(web::resource("/").route(web::get().to(index)))
+            .service(web::resource("/{lang}").route(web::get().to(home)))
+            .service(web::resource("/{lang}/about").route(web::get().to(about)))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}

--- a/examples/basic-actix-askama-multilingual-site/templates/about/about-en.html
+++ b/examples/basic-actix-askama-multilingual-site/templates/about/about-en.html
@@ -1,0 +1,10 @@
+{% extends "commons/base-en.html" %}
+{% block title %}{{title}}{% endblock %}
+{% block head %}
+<style>
+</style>
+{% endblock %}
+{% block content %}
+<h1>About-{{lang}}</h1>
+<p>English About</p>
+{% endblock %}

--- a/examples/basic-actix-askama-multilingual-site/templates/about/about-it.html
+++ b/examples/basic-actix-askama-multilingual-site/templates/about/about-it.html
@@ -1,0 +1,10 @@
+{% extends "commons/base-it.html" %}
+{% block title %}{{title}}{% endblock %}
+{% block head %}
+<style>
+</style>
+{% endblock %}
+{% block content %}
+<h1>About-{{lang}}</h1>
+<p>Italian About</p>
+{% endblock %}

--- a/examples/basic-actix-askama-multilingual-site/templates/commons/base-en.html
+++ b/examples/basic-actix-askama-multilingual-site/templates/commons/base-en.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{% block title %}{{ title }}{% endblock %}</title>
+    {% block head %}{% endblock %}
+</head>
+<body>
+<div class="navbar">
+    <a href="/{{lang}}">Home</a>
+    <a href="/{{lang}}/about">About</a>
+    {% if page == "home" %}
+        <a href="/it">Italian</a>
+    {% endif %}
+    {% if page == "about" %}
+        <a href="/it/about">Italian</a>
+    {% endif %}
+</div>
+<div id="content">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/examples/basic-actix-askama-multilingual-site/templates/commons/base-it.html
+++ b/examples/basic-actix-askama-multilingual-site/templates/commons/base-it.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <title>{% block title %}{{ title }}{% endblock %}</title>
+    {% block head %}{% endblock %}
+</head>
+<body>
+<div class="navbar">
+    <a href="/{{lang}}">Home</a>
+    <a href="/{{lang}}/about">About</a>
+    {% if page == "home" %}
+        <a href="/en">English</a>
+    {% endif %}
+    {% if page == "about" %}
+        <a href="/en/about">English</a>
+    {% endif %}
+</div>
+<div id="content">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/examples/basic-actix-askama-multilingual-site/templates/home/home-en.html
+++ b/examples/basic-actix-askama-multilingual-site/templates/home/home-en.html
@@ -1,0 +1,10 @@
+{% extends "commons/base-en.html" %}
+{% block title %}{{title}}{% endblock %}
+{% block head %}
+<style>
+</style>
+{% endblock %}
+{% block content %}
+<h1>Home-{{lang}}</h1>
+<p>English Home</p>
+{% endblock %}

--- a/examples/basic-actix-askama-multilingual-site/templates/home/home-it.html
+++ b/examples/basic-actix-askama-multilingual-site/templates/home/home-it.html
@@ -1,0 +1,10 @@
+{% extends "commons/base-it.html" %}
+{% block title %}{{title}}{% endblock %}
+{% block head %}
+<style>
+</style>
+{% endblock %}
+{% block content %}
+<h1>Home-{{lang}}</h1>
+<p>Italian Home</p>
+{% endblock %}


### PR DESCRIPTION
I created a basic multi-language site with two pages (Home and About). For each page, I used two template structs with the same content. A possible next step is to create a newtype wrapped around an inner type with a Deref impl to share the same type definitions for the template structs. Here is the repository create on my GitHub account: git@github.com:gpmake/basic-actix-askama-multilingual-site.git