### PR TITLE
Replace `&PathBuf` with `&Path`

### DIFF
--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -46,7 +46,7 @@ fn build_template(ast: &syn::DeriveInput) -> Result<String, CompileError> {
 
     let mut parsed = HashMap::new();
     for (path, src) in &sources {
-        parsed.insert(path, parse(src, input.syntax)?);
+        parsed.insert(path.as_path(), parse(src, input.syntax)?);
     }
 
     let mut contexts = HashMap::new();
@@ -54,7 +54,7 @@ fn build_template(ast: &syn::DeriveInput) -> Result<String, CompileError> {
         contexts.insert(*path, Context::new(input.config, path, nodes)?);
     }
 
-    let ctx = &contexts[&input.path];
+    let ctx = &contexts[input.path.as_path()];
     let heritage = if !ctx.blocks.is_empty() || ctx.extends.is_some() {
         Some(Heritage::new(ctx, &contexts))
     } else {
@@ -62,7 +62,7 @@ fn build_template(ast: &syn::DeriveInput) -> Result<String, CompileError> {
     };
 
     if input.print == Print::Ast || input.print == Print::All {
-        eprintln!("{:?}", parsed[&input.path]);
+        eprintln!("{:?}", parsed[input.path.as_path()]);
     }
 
     let code = generator::generate(&input, &contexts, heritage.as_ref(), INTEGRATIONS)?;

--- a/askama_shared/src/heritage.rs
+++ b/askama_shared/src/heritage.rs
@@ -12,7 +12,7 @@ pub struct Heritage<'a> {
 impl Heritage<'_> {
     pub fn new<'n, S: std::hash::BuildHasher>(
         mut ctx: &'n Context<'n>,
-        contexts: &'n HashMap<&'n PathBuf, Context<'n>, S>,
+        contexts: &'n HashMap<&'n Path, Context<'n>, S>,
     ) -> Heritage<'n> {
         let mut blocks: BlockAncestry<'n> = ctx
             .blocks
@@ -21,7 +21,7 @@ impl Heritage<'_> {
             .collect();
 
         while let Some(ref path) = ctx.extends {
-            ctx = &contexts[&path];
+            ctx = &contexts[path.as_path()];
             for (name, def) in &ctx.blocks {
                 blocks.entry(name).or_insert_with(Vec::new).push((ctx, def));
             }


### PR DESCRIPTION
PathBuf is to String like Path is to str, so `&PathBuf` is a pointer to a pointer. Clippy does not likes that.

In #600 clippy did notice the problem after some refactoring. This change is at least a little useful on its own.