### PR TITLE
Parse tuple expressions

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -1061,6 +1061,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
             Expr::Call(ref obj, ref args) => self.visit_call(buf, obj, args)?,
             Expr::RustMacro(name, args) => self.visit_rust_macro(buf, name, args),
             Expr::Try(ref expr) => self.visit_try(buf, expr.as_ref())?,
+            Expr::Tuple(ref exprs) => self.visit_tuple(buf, exprs)?,
         })
     }
 
@@ -1399,6 +1400,23 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     ) -> Result<DisplayWrap, CompileError> {
         buf.write("(");
         self.visit_expr(buf, inner)?;
+        buf.write(")");
+        Ok(DisplayWrap::Unwrapped)
+    }
+
+    fn visit_tuple(
+        &mut self,
+        buf: &mut Buffer,
+        exprs: &[Expr<'_>],
+    ) -> Result<DisplayWrap, CompileError> {
+        buf.write("(");
+        for (index, expr) in exprs.iter().enumerate() {
+            if index > 0 {
+                buf.write(" ");
+            }
+            self.visit_expr(buf, expr)?;
+            buf.write(",");
+        }
         buf.write(")");
         Ok(DisplayWrap::Unwrapped)
     }

--- a/testing/tests/tuple.rs
+++ b/testing/tests/tuple.rs
@@ -1,0 +1,82 @@
+use askama::Template;
+
+struct Post {
+    id: u32,
+}
+
+struct Client<'a> {
+    can_post_ids: &'a [u32],
+    can_update_ids: &'a [u32],
+}
+
+impl Client<'_> {
+    fn can_post(&self, post: &Post) -> bool {
+        self.can_post_ids.contains(&post.id)
+    }
+
+    fn can_update(&self, post: &Post) -> bool {
+        self.can_update_ids.contains(&post.id)
+    }
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"
+{%- match (client.can_post(post), client.can_update(post)) -%}
+    {%- when (false, false) -%}
+        No!
+    {%- when (can_post, can_update) -%}
+        <ul>
+        {%- if can_post -%}<li>post</li>{%- endif -%}
+        {%- if can_update -%}<li>update</li>{%- endif -%}
+        </ul>
+{%- endmatch -%}
+"#,
+    ext = "txt"
+)]
+struct TupleTemplate<'a> {
+    client: &'a Client<'a>,
+    post: &'a Post,
+}
+
+#[test]
+fn test_tuple() {
+    let template = TupleTemplate {
+        client: &Client {
+            can_post_ids: &[1, 2],
+            can_update_ids: &[2, 3],
+        },
+        post: &Post { id: 1 },
+    };
+    assert_eq!(template.render().unwrap(), "<ul><li>post</li></ul>");
+
+    let template = TupleTemplate {
+        client: &Client {
+            can_post_ids: &[1, 2],
+            can_update_ids: &[2, 3],
+        },
+        post: &Post { id: 2 },
+    };
+    assert_eq!(
+        template.render().unwrap(),
+        "<ul><li>post</li><li>update</li></ul>"
+    );
+
+    let template = TupleTemplate {
+        client: &Client {
+            can_post_ids: &[1, 2],
+            can_update_ids: &[2, 3],
+        },
+        post: &Post { id: 3 },
+    };
+    assert_eq!(template.render().unwrap(), "<ul><li>update</li></ul>");
+
+    let template = TupleTemplate {
+        client: &Client {
+            can_post_ids: &[1, 2],
+            can_update_ids: &[2, 3],
+        },
+        post: &Post { id: 4 },
+    };
+    assert_eq!(template.render().unwrap(), "No!");
+}


### PR DESCRIPTION
Askama understands how to destructure tuples in let and match
statements, but it does not understand how to build a tuple.

This PR fixes this shortcoming.