### PR TITLE
Support single-expression closures in templates

### DIFF
--- a/askama_shared/src/generator.rs
+++ b/askama_shared/src/generator.rs
@@ -542,7 +542,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         ctx: &'a Context<'_>,
         buf: &mut Buffer,
         ws1: Ws,
-        expr: &Expr<'_>,
+        expr: &Expr<'a>,
         arms: &'a [When<'_>],
         ws2: Ws,
     ) -> Result<usize, CompileError> {
@@ -659,7 +659,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         ws: Ws,
         scope: Option<&str>,
         name: &str,
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<usize, CompileError> {
         if name == "super" {
             return self.write_block(buf, None, ws);
@@ -832,7 +832,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         buf: &mut Buffer,
         ws: Ws,
         var: &'a Target<'_>,
-        val: &Expr<'_>,
+        val: &Expr<'a>,
     ) -> Result<(), CompileError> {
         self.handle_ws(ws);
         let mut expr_buf = Buffer::new(0);
@@ -1032,7 +1032,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
 
     /* Visitor methods for expression types */
 
-    fn visit_expr_root(&mut self, expr: &Expr<'_>) -> Result<String, CompileError> {
+    fn visit_expr_root(&mut self, expr: &Expr<'a>) -> Result<String, CompileError> {
         let mut buf = Buffer::new(0);
         self.visit_expr(&mut buf, expr)?;
         Ok(buf.buf)
@@ -1041,7 +1041,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn visit_expr(
         &mut self,
         buf: &mut Buffer,
-        expr: &Expr<'_>,
+        expr: &Expr<'a>,
     ) -> Result<DisplayWrap, CompileError> {
         Ok(match *expr {
             Expr::BoolLit(s) => self.visit_bool_lit(buf, s),
@@ -1081,7 +1081,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         &mut self,
         buf: &mut Buffer,
         mut name: &str,
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<DisplayWrap, CompileError> {
         if matches!(name, "escape" | "e") {
             self._visit_escape_filter(buf, args)?;
@@ -1133,7 +1133,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn _visit_escape_filter(
         &mut self,
         buf: &mut Buffer,
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<(), CompileError> {
         if args.len() > 2 {
             return Err("only two arguments allowed to escape filter".into());
@@ -1164,7 +1164,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn _visit_format_filter(
         &mut self,
         buf: &mut Buffer,
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<(), CompileError> {
         buf.write("format!(");
         if let Some(Expr::StrLit(v)) = args.first() {
@@ -1183,7 +1183,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn _visit_fmt_filter(
         &mut self,
         buf: &mut Buffer,
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<(), CompileError> {
         buf.write("format!(");
         if let Some(Expr::StrLit(v)) = args.get(1) {
@@ -1204,7 +1204,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn _visit_join_filter(
         &mut self,
         buf: &mut Buffer,
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<(), CompileError> {
         buf.write("::askama::filters::join((&");
         for (i, arg) in args.iter().enumerate() {
@@ -1220,7 +1220,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         Ok(())
     }
 
-    fn _visit_args(&mut self, buf: &mut Buffer, args: &[Expr<'_>]) -> Result<(), CompileError> {
+    fn _visit_args(&mut self, buf: &mut Buffer, args: &[Expr<'a>]) -> Result<(), CompileError> {
         if args.is_empty() {
             return Ok(());
         }
@@ -1261,7 +1261,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn visit_attr(
         &mut self,
         buf: &mut Buffer,
-        obj: &Expr<'_>,
+        obj: &Expr<'a>,
         attr: &str,
     ) -> Result<DisplayWrap, CompileError> {
         if let Expr::Var(name) = *obj {
@@ -1291,8 +1291,8 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn visit_index(
         &mut self,
         buf: &mut Buffer,
-        obj: &Expr<'_>,
-        key: &Expr<'_>,
+        obj: &Expr<'a>,
+        key: &Expr<'a>,
     ) -> Result<DisplayWrap, CompileError> {
         buf.write("&");
         self.visit_expr(buf, obj)?;
@@ -1305,9 +1305,9 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn visit_method_call(
         &mut self,
         buf: &mut Buffer,
-        obj: &Expr<'_>,
+        obj: &Expr<'a>,
         method: &str,
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<DisplayWrap, CompileError> {
         if matches!(obj, Expr::Var("loop")) {
             match method {
@@ -1380,7 +1380,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         &mut self,
         buf: &mut Buffer,
         op: &str,
-        inner: &Expr<'_>,
+        inner: &Expr<'a>,
     ) -> Result<DisplayWrap, CompileError> {
         buf.write(op);
         self.visit_expr(buf, inner)?;
@@ -1391,8 +1391,8 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         &mut self,
         buf: &mut Buffer,
         op: &str,
-        left: &Option<Box<Expr<'_>>>,
-        right: &Option<Box<Expr<'_>>>,
+        left: &Option<Box<Expr<'a>>>,
+        right: &Option<Box<Expr<'a>>>,
     ) -> Result<DisplayWrap, CompileError> {
         if let Some(left) = left {
             self.visit_expr(buf, left)?;
@@ -1408,8 +1408,8 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         &mut self,
         buf: &mut Buffer,
         op: &str,
-        left: &Expr<'_>,
-        right: &Expr<'_>,
+        left: &Expr<'a>,
+        right: &Expr<'a>,
     ) -> Result<DisplayWrap, CompileError> {
         self.visit_expr(buf, left)?;
         buf.write(&format!(" {} ", op));
@@ -1420,7 +1420,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn visit_group(
         &mut self,
         buf: &mut Buffer,
-        inner: &Expr<'_>,
+        inner: &Expr<'a>,
     ) -> Result<DisplayWrap, CompileError> {
         buf.write("(");
         self.visit_expr(buf, inner)?;
@@ -1431,7 +1431,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
     fn visit_array(
         &mut self,
         buf: &mut Buffer,
-        elements: &[Expr<'_>],
+        elements: &[Expr<'a>],
     ) -> Result<DisplayWrap, CompileError> {
         buf.write("[");
         for (i, el) in elements.iter().enumerate() {
@@ -1458,7 +1458,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         &mut self,
         buf: &mut Buffer,
         path: &[&str],
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<DisplayWrap, CompileError> {
         for (i, part) in path.iter().enumerate() {
             if i > 0 {
@@ -1486,7 +1486,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         &mut self,
         buf: &mut Buffer,
         s: &str,
-        args: &[Expr<'_>],
+        args: &[Expr<'a>],
     ) -> Result<DisplayWrap, CompileError> {
         buf.write("(");
         let s = normalize_identifier(s);

--- a/testing/tests/closures.rs
+++ b/testing/tests/closures.rs
@@ -1,7 +1,5 @@
 use askama::Template;
 
-const FALSE: &bool = &false;
-
 #[derive(Debug, Clone)]
 struct User {
     name: String,
@@ -59,7 +57,7 @@ fn test_closure_shadow() {
 
 #[derive(Template)]
 #[template(
-    source = r#"{{ user_opt.map(|user| user.flag).unwrap_or(FALSE) }}"#,
+    source = r#"{{ user_opt.map(|user| user.flag).copied().unwrap_or(false) }}"#,
     ext = "txt"
 )]
 struct ClosureBorrowTemplate<'a> {

--- a/testing/tests/closures.rs
+++ b/testing/tests/closures.rs
@@ -1,0 +1,79 @@
+use askama::Template;
+
+const FALSE: &'static bool = &false;
+
+#[derive(Debug, Clone)]
+struct User {
+    name: String,
+    flag: bool,
+}
+
+impl User {
+    fn ferris() -> Self {
+        Self {
+            name: "Ferris".to_string(),
+            flag: true,
+        }
+    }
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"Hello {{ user_opt.map(|user| user.name.as_str()).unwrap_or("World") }}"#,
+    ext = "txt"
+)]
+struct ClosureTemplate<'a> {
+    user_opt: Option<&'a User>,
+}
+
+#[test]
+fn test_closure() {
+    let user = User::ferris();
+    let t = ClosureTemplate {
+        user_opt: Some(&user),
+    };
+    assert_eq!(t.render().unwrap(), "Hello Ferris");
+
+    let t = ClosureTemplate { user_opt: None };
+    assert_eq!(t.render().unwrap(), "Hello World");
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"Hello {{ user.map(|user| user.name.as_str()).unwrap_or("World") }}"#,
+    ext = "txt"
+)]
+struct ClosureShadowTemplate<'a> {
+    user: Option<&'a User>,
+}
+
+#[test]
+fn test_closure_shadow() {
+    let user = User::ferris();
+    let t = ClosureShadowTemplate { user: Some(&user) };
+    assert_eq!(t.render().unwrap(), "Hello Ferris");
+
+    let t = ClosureShadowTemplate { user: None };
+    assert_eq!(t.render().unwrap(), "Hello World");
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"{{ user_opt.map(|user| user.flag).unwrap_or(FALSE) }}"#,
+    ext = "txt"
+)]
+struct ClosureBorrowTemplate<'a> {
+    user_opt: Option<&'a User>,
+}
+
+#[test]
+fn test_closure_borrow() {
+    let user = User::ferris();
+    let t = ClosureBorrowTemplate {
+        user_opt: Some(&user),
+    };
+    assert_eq!(t.render().unwrap(), "true");
+
+    let t = ClosureBorrowTemplate { user_opt: None };
+    assert_eq!(t.render().unwrap(), "false");
+}

--- a/testing/tests/closures.rs
+++ b/testing/tests/closures.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 
-const FALSE: &'static bool = &false;
+const FALSE: &bool = &false;
 
 #[derive(Debug, Clone)]
 struct User {


### PR DESCRIPTION
Fixes #284 (and #398?)

## Example

```rust
use askama::Template;

#[derive(Debug, Clone)]
struct User { name: String }

impl User {
    fn ferris() -> Self { Self { name: "Ferris".to_string() } }
}

#[derive(Template)]
#[template(
    source = r#"Hello {{ user_opt.map(|user| user.name.as_str()).unwrap_or("World") }}"#,
    ext = "txt"
)]
struct ClosureTemplate<'a> {
    user_opt: Option<&'a User>,
}

#[test]
fn test_closure() {
    let user = User::ferris();
    let t = ClosureTemplate { user_opt: Some(&user) };
    assert_eq!(t.render().unwrap(), "Hello Ferris");

    let t = ClosureTemplate { user_opt: None };
    assert_eq!(t.render().unwrap(), "Hello World");
}
```

## Drawbacks

I think the only inconvenience of the current implementation is that `Copy` types can cause problems in combination with the automatic borrowing, see below. This should always be fixable by a clone, in this case `data.flag.clone()`. (Edit: Or by using `copied` on the Option as mentioned by @vallentin)

The alternative would be to not automatically borrow the closure expression. But then non `Copy` types would not work anymore.

```rust
struct Data {
    flag: bool,
}

#[derive(Template)]
#[template(
    source = r#"{{ data_opt.map(|data| data.flag).unwrap_or(false) }}"#,
    ext = "txt"
)]
struct DataTemplate {
    data_opt: Option<Data>,
}

// error[E0308]: mismatched types
//   --> testing\tests\closures.rs:85:10
//    |
// 85 | #[derive(Template)]
//    |          ^^^^^^^^ expected `&bool`, found `bool`
//    |
```