### PR TITLE
Remove support for deprecated `_parent` field

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -293,11 +293,6 @@ impl<'a> Generator<'a> {
     // Takes a Context and generates the relevant implementations.
     fn build(mut self, ctx: &'a Context<'_>) -> Result<String, CompileError> {
         let mut buf = Buffer::new(0);
-        if !ctx.blocks.is_empty() {
-            if let Some(parent) = self.input.parent {
-                self.deref_to_parent(&mut buf, parent)?;
-            }
-        };
 
         self.impl_template(ctx, &mut buf)?;
         self.impl_display(&mut buf)?;
@@ -374,24 +369,6 @@ impl<'a> Generator<'a> {
 
         buf.writeln("}")?;
         Ok(())
-    }
-
-    // Implement `Deref<Parent>` for an inheriting context struct.
-    fn deref_to_parent(
-        &mut self,
-        buf: &mut Buffer,
-        parent_type: &syn::Type,
-    ) -> Result<(), CompileError> {
-        self.write_header(buf, "::std::ops::Deref", None)?;
-        buf.writeln(&format!(
-            "type Target = {};",
-            parent_type.into_token_stream()
-        ))?;
-        buf.writeln("#[inline]")?;
-        buf.writeln("fn deref(&self) -> &Self::Target {")?;
-        buf.writeln("&self._parent")?;
-        buf.writeln("}")?;
-        buf.writeln("}")
     }
 
     // Implement `Display` for the given context struct.

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -16,15 +16,13 @@ pub(crate) struct TemplateInput<'a> {
     pub(crate) escaper: &'a str,
     pub(crate) ext: Option<String>,
     pub(crate) mime_type: String,
-    pub(crate) parent: Option<&'a syn::Type>,
     pub(crate) path: PathBuf,
 }
 
 impl TemplateInput<'_> {
     /// Extract the template metadata from the `DeriveInput` structure. This
     /// mostly recovers the data for the `TemplateInput` fields from the
-    /// `template()` attribute list fields; it also finds the of the `_parent`
-    /// field, if any.
+    /// `template()` attribute list fields.
     pub(crate) fn new<'n>(
         ast: &'n syn::DeriveInput,
         config: &'n Config<'_>,
@@ -50,27 +48,6 @@ impl TemplateInput<'_> {
                 return Err("must include 'ext' attribute when using 'source' attribute".into())
             }
         };
-
-        // Check to see if a `_parent` field was defined on the context
-        // struct, and store the type for it for use in the code generator.
-        let parent = match ast.data {
-            syn::Data::Struct(syn::DataStruct {
-                fields: syn::Fields::Named(ref fields),
-                ..
-            }) => fields
-                .named
-                .iter()
-                .find(|f| f.ident.as_ref().filter(|name| *name == "_parent").is_some())
-                .map(|f| &f.ty),
-            _ => None,
-        };
-
-        if parent.is_some() {
-            eprint!(
-                "   --> in struct {}\n   = use of deprecated field '_parent'\n",
-                ast.ident
-            );
-        }
 
         // Validate syntax
         let syntax = syntax.map_or_else(
@@ -117,7 +94,6 @@ impl TemplateInput<'_> {
             escaper,
             ext,
             mime_type,
-            parent,
             path,
         })
     }


### PR DESCRIPTION
The support for the magic `_parent` field is deprecated since v0.8.0
or issue #180. It's bothersome to keep this feature alive, when no-one
should be using it for 3 years.