### PR TITLE
Use exact trybuild version

### DIFF
--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
-trybuild = "1.0"
+trybuild = "1.0.55"
 version_check = "0.9"
 
 [[bench]]


### PR DESCRIPTION
Sometimes for no obvious reason an old version is selected and the
output is different in just about every ui test. Just pin it to the
currently newest version and test if an updated version still works when
a new version gets released.