### PR TITLE
Remove ext argument in integrations (breaking change)

### DIFF
--- a/askama_axum/src/lib.rs
+++ b/askama_axum/src/lib.rs
@@ -6,7 +6,7 @@ pub use askama::*;
 pub use axum_core::response::{IntoResponse, Response};
 use http::StatusCode;
 
-pub fn into_response<T: Template>(t: &T, _ext: &str) -> Response {
+pub fn into_response<T: Template>(t: &T) -> Response {
     match t.render() {
         Ok(body) => {
             let headers = [(

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -428,8 +428,7 @@ impl<'a> Generator<'a> {
             "fn into_response(self)\
              -> ::askama_axum::Response {",
         )?;
-        let ext = self.input.extension().unwrap_or("txt");
-        buf.writeln(&format!("::askama_axum::into_response(&self, {:?})", ext))?;
+        buf.writeln("::askama_axum::into_response(&self)")?;
         buf.writeln("}")?;
         buf.writeln("}")
     }
@@ -443,8 +442,7 @@ impl<'a> Generator<'a> {
             "fn into_response(self, _state: &::askama_gotham::State)\
              -> ::askama_gotham::Response<::askama_gotham::Body> {",
         )?;
-        let ext = self.input.extension().unwrap_or("txt");
-        buf.writeln(&format!("::askama_gotham::respond(&self, {:?})", ext))?;
+        buf.writeln("::askama_gotham::respond(&self)")?;
         buf.writeln("}")?;
         buf.writeln("}")
     }
@@ -490,10 +488,7 @@ impl<'a> Generator<'a> {
              -> ::mendes::http::Response<A::ResponseBody> {",
         )?;
 
-        buf.writeln(&format!(
-            "::askama_mendes::into_response(app, req, &self, {:?})",
-            self.input.extension()
-        ))?;
+        buf.writeln("::askama_mendes::into_response(app, req, &self)")?;
         buf.writeln("}")?;
         buf.writeln("}")?;
         Ok(())
@@ -515,8 +510,7 @@ impl<'a> Generator<'a> {
             "fn respond_to(self, _: &::askama_rocket::Request) \
              -> ::askama_rocket::Result<'askama> {",
         )?;
-        let ext = self.input.extension().unwrap_or("txt");
-        buf.writeln(&format!("::askama_rocket::respond(&self, {:?})", ext))?;
+        buf.writeln("::askama_rocket::respond(&self)")?;
 
         buf.writeln("}")?;
         buf.writeln("}")?;
@@ -525,8 +519,6 @@ impl<'a> Generator<'a> {
 
     #[cfg(feature = "with-tide")]
     fn impl_tide_integrations(&mut self, buf: &mut Buffer) -> Result<(), CompileError> {
-        let ext = self.input.extension().unwrap_or("txt");
-
         self.write_header(
             buf,
             "::std::convert::TryInto<::askama_tide::tide::Body>",
@@ -537,7 +529,7 @@ impl<'a> Generator<'a> {
             #[inline]\n\
             fn try_into(self) -> ::askama_tide::askama::Result<::askama_tide::tide::Body> {",
         )?;
-        buf.writeln(&format!("::askama_tide::try_into_body(&self, {:?})", &ext))?;
+        buf.writeln("::askama_tide::try_into_body(&self)")?;
         buf.writeln("}")?;
         buf.writeln("}")?;
 
@@ -545,7 +537,7 @@ impl<'a> Generator<'a> {
         self.write_header(buf, "Into<::askama_tide::tide::Response>", None)?;
         buf.writeln("#[inline]")?;
         buf.writeln("fn into(self) -> ::askama_tide::tide::Response {")?;
-        buf.writeln(&format!("::askama_tide::into_response(&self, {:?})", ext))?;
+        buf.writeln("::askama_tide::into_response(&self)")?;
         buf.writeln("}\n}")
     }
 
@@ -554,8 +546,7 @@ impl<'a> Generator<'a> {
         self.write_header(buf, "::askama_warp::warp::reply::Reply", None)?;
         buf.writeln("#[inline]")?;
         buf.writeln("fn into_response(self) -> ::askama_warp::warp::reply::Response {")?;
-        let ext = self.input.extension().unwrap_or("txt");
-        buf.writeln(&format!("::askama_warp::reply(&self, {:?})", ext))?;
+        buf.writeln("::askama_warp::reply(&self)")?;
         buf.writeln("}")?;
         buf.writeln("}")
     }

--- a/askama_gotham/src/lib.rs
+++ b/askama_gotham/src/lib.rs
@@ -9,7 +9,7 @@ use gotham::hyper::header;
 pub use gotham::hyper::{Body, Response, StatusCode};
 pub use gotham::state::State;
 
-pub fn respond<T: Template>(t: &T, _ext: &str) -> Response<Body> {
+pub fn respond<T: Template>(t: &T) -> Response<Body> {
     match t.render() {
         Ok(body) => Response::builder()
             .status(StatusCode::OK)

--- a/askama_mendes/src/lib.rs
+++ b/askama_mendes/src/lib.rs
@@ -9,12 +9,7 @@ use mendes::http::Response;
 
 pub use askama::*;
 
-pub fn into_response<A, T>(
-    app: &A,
-    req: &Parts,
-    t: &T,
-    _ext: Option<&str>,
-) -> Response<A::ResponseBody>
+pub fn into_response<A, T>(app: &A, req: &Parts, t: &T) -> Response<A::ResponseBody>
 where
     A: Application,
     T: Template,

--- a/askama_rocket/src/lib.rs
+++ b/askama_rocket/src/lib.rs
@@ -10,7 +10,7 @@ pub use rocket::request::Request;
 use rocket::response::Response;
 pub use rocket::response::{Responder, Result};
 
-pub fn respond<T: Template>(t: &T, _ext: &str) -> Result<'static> {
+pub fn respond<T: Template>(t: &T) -> Result<'static> {
     let rsp = t.render().map_err(|_| Status::InternalServerError)?;
     Response::build()
         .header(Header::new("content-type", T::MIME_TYPE))

--- a/askama_tide/src/lib.rs
+++ b/askama_tide/src/lib.rs
@@ -8,15 +8,15 @@ pub use tide;
 use askama::*;
 use tide::{Body, Response};
 
-pub fn try_into_body<T: Template>(t: &T, _ext: &str) -> Result<Body> {
+pub fn try_into_body<T: Template>(t: &T) -> Result<Body> {
     let string = t.render()?;
     let mut body = Body::from_string(string);
     body.set_mime(T::MIME_TYPE);
     Ok(body)
 }
 
-pub fn into_response<T: Template>(t: &T, ext: &str) -> Response {
-    match try_into_body(t, ext) {
+pub fn into_response<T: Template>(t: &T) -> Response {
+    match try_into_body(t) {
         Ok(body) => {
             let mut response = Response::new(200);
             response.set_body(body);

--- a/askama_warp/src/lib.rs
+++ b/askama_warp/src/lib.rs
@@ -9,7 +9,7 @@ use warp::http::{self, header, StatusCode};
 use warp::hyper::Body;
 use warp::reply::Response;
 
-pub fn reply<T: askama::Template>(t: &T, _ext: &str) -> Response {
+pub fn reply<T: askama::Template>(t: &T) -> Response {
     match t.render() {
         Ok(body) => http::Response::builder()
             .status(StatusCode::OK)


### PR DESCRIPTION
Lest the diff gets forgotten! :)

This change was part of #594, but deferred until the next big release, because it breaks backward compatibility. 