### PR TITLE
Skip caching calls (Resolves #667)

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -7,7 +7,7 @@ use crate::CompileError;
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 
-use std::collections::HashMap;
+use std::collections::hash_map::{Entry, HashMap};
 use std::path::{Path, PathBuf};
 use std::{cmp, hash, mem, str};
 
@@ -1196,11 +1196,9 @@ impl<'a> Generator<'a> {
                             expr_buf.buf, self.input.escaper
                         ),
                     };
-                    let is_cacheable = !matches!(s, Expr::Call(..));
 
-                    use std::collections::hash_map::Entry;
                     let id = match expr_cache.entry(expression.clone()) {
-                        Entry::Occupied(e) if is_cacheable => *e.get(),
+                        Entry::Occupied(e) if s.is_cachable() => *e.get(),
                         e => {
                             let id = self.named;
                             self.named += 1;

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -1196,11 +1196,12 @@ impl<'a> Generator<'a> {
                             expr_buf.buf, self.input.escaper
                         ),
                     };
+                    let is_cacheable = !matches!(s, Expr::Call(..));
 
                     use std::collections::hash_map::Entry;
                     let id = match expr_cache.entry(expression.clone()) {
-                        Entry::Occupied(e) => *e.get(),
-                        Entry::Vacant(e) => {
+                        Entry::Occupied(e) if is_cacheable => *e.get(),
+                        e => {
                             let id = self.named;
                             self.named += 1;
 
@@ -1209,7 +1210,10 @@ impl<'a> Generator<'a> {
                             buf_expr.write(&expression);
                             buf_expr.writeln(",")?;
 
-                            e.insert(id);
+                            if let Entry::Vacant(e) = e {
+                                e.insert(id);
+                            }
+
                             id
                         }
                     };


### PR DESCRIPTION
This is just a quick fix to address #667, and open up discussion.

Should we take any assumptions about interior mutability, statics and side-effects? i.e. never cache calls. Someone could potentially even make a "funky" `impl Deref`, making caching field accesses "wrong".

Alternative suggestion, we could introduce a config to disable caching.

(I'll add tests, update docs, etc. when I know whether we want a config or just take no assumptions and not cache)

-----

New behavior:

```jinja
{{ foo() }} {{ foo() }} {{ bar }}  {{ bar }}
```

Now generates:

```rust
::std::write!(
    writer,
    "{expr0} {expr1} {expr2}  {expr2}",
    expr0 = &::askama::MarkupDisplay::new_unsafe(&(self.foo()), ::askama::Text),
    expr1 = &::askama::MarkupDisplay::new_unsafe(&(self.foo()), ::askama::Text),
    expr2 = &::askama::MarkupDisplay::new_unsafe(&(self.bar), ::askama::Text),
)?;
```
