### PR TITLE
Fix invalid check

### DIFF
--- a/askama_shared/src/lib.rs
+++ b/askama_shared/src/lib.rs
@@ -275,8 +275,8 @@ impl<'a> TryFrom<RawSyntax<'a>> for Syntax<'a> {
         let be = syntax.block_start.as_bytes()[1];
         let cs = syntax.comment_start.as_bytes()[0];
         let ce = syntax.comment_start.as_bytes()[1];
-        let es = syntax.block_start.as_bytes()[0];
-        let ee = syntax.block_start.as_bytes()[1];
+        let es = syntax.expr_start.as_bytes()[0];
+        let ee = syntax.expr_start.as_bytes()[1];
         if !((bs == cs && bs == es) || (be == ce && be == ee)) {
             return Err(format!("bad delimiters block_start: {}, comment_start: {}, expr_start: {}, needs one of the two characters in common", syntax.block_start, syntax.comment_start, syntax.expr_start).into());
         }


### PR DESCRIPTION
`block_start` is already checked just above.

Also a question about this code: shouldn't the character in common be between `*_start` and `*_end` instead of the current code?