### PR TITLE
Allow `{% endmacro name %}`

### DIFF
--- a/testing/templates/macro.html
+++ b/testing/templates/macro.html
@@ -11,3 +11,15 @@
 {%- call thrice(s) -%}
 
 3
+
+{%- macro twice(param) -%}
+
+{{ param }} {{ param }}
+
+{%- endmacro twice -%}
+
+4
+
+{%- call twice(s) -%}
+
+5

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -9,7 +9,7 @@ struct MacroTemplate<'a> {
 #[test]
 fn test_macro() {
     let t = MacroTemplate { s: "foo" };
-    assert_eq!(t.render().unwrap(), "12foo foo foo3");
+    assert_eq!(t.render().unwrap(), "12foo foo foo34foo foo5");
 }
 
 #[derive(Template)]


### PR DESCRIPTION
Just migrated a repo from tera to askama and this was one of the only
things that was different. This is also coherent with `{% block %}` for
which I added the same feature years ago.