### PR TITLE
Document macro import syntax.

### DIFF
--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -390,3 +390,11 @@ You can then call it later with `{% call name(args) %}`
 
 {% call heading(s) %}
 ```
+
+You can place templates in a separate file and use it in your templates by using `{% import %}`
+
+```
+{%- import "macro.html" as scope -%}
+
+{% call scope::heading(s) %}
+```


### PR DESCRIPTION
This was a source of some frustration working on a port of a toy app to askama. The tests do help, but having this called out in the docs would have saved me an hour or two.

If merged, I assign the rights to this contribution to @djc.