### PR TITLE
Remove hash builder parameter from generator

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -229,11 +229,12 @@ fn find_used_templates(
     }
     Ok(())
 }
-struct Generator<'a, S: std::hash::BuildHasher> {
+
+struct Generator<'a> {
     // The template input state: original struct AST and attributes
     input: &'a TemplateInput<'a>,
     // All contexts, keyed by the package-relative template path
-    contexts: &'a HashMap<&'a Path, Context<'a>, S>,
+    contexts: &'a HashMap<&'a Path, Context<'a>>,
     // The heritage contains references to blocks and their ancestry
     heritage: Option<&'a Heritage<'a>>,
     // Variables accessible directly from the current scope (not redirected to context)
@@ -256,14 +257,14 @@ struct Generator<'a, S: std::hash::BuildHasher> {
     whitespace: WhitespaceHandling,
 }
 
-impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
+impl<'a> Generator<'a> {
     fn new<'n>(
         input: &'n TemplateInput<'_>,
-        contexts: &'n HashMap<&'n Path, Context<'n>, S>,
+        contexts: &'n HashMap<&'n Path, Context<'n>>,
         heritage: Option<&'n Heritage<'_>>,
         locals: MapChain<'n, &'n str, LocalMeta>,
         whitespace: WhitespaceHandling,
-    ) -> Generator<'n, S> {
+    ) -> Generator<'n> {
         Generator {
             input,
             contexts,
@@ -278,7 +279,7 @@ impl<'a, S: std::hash::BuildHasher> Generator<'a, S> {
         }
     }
 
-    fn child(&mut self) -> Generator<'_, S> {
+    fn child(&mut self) -> Generator<'_> {
         let locals = MapChain::with_parent(&self.locals);
         Self::new(
             self.input,

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -11,9 +11,9 @@ pub(crate) struct Heritage<'a> {
 }
 
 impl Heritage<'_> {
-    pub(crate) fn new<'n, S: std::hash::BuildHasher>(
+    pub(crate) fn new<'n>(
         mut ctx: &'n Context<'n>,
-        contexts: &'n HashMap<&'n Path, Context<'n>, S>,
+        contexts: &'n HashMap<&'n Path, Context<'n>>,
     ) -> Heritage<'n> {
         let mut blocks: BlockAncestry<'n> = ctx
             .blocks


### PR DESCRIPTION
The generator cannot be accessed outside of crate, so it's not possible to override the default hasher.