### PR TITLE
Replace `&Option<Box<T>>` with `Option<&T>`

### DIFF
--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -249,7 +249,7 @@ struct RawEscaper<'a> {
 }
 
 pub(crate) fn read_config_file(
-    config_path: &Option<String>,
+    config_path: Option<&str>,
 ) -> std::result::Result<String, CompileError> {
     let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let filename = match config_path {


### PR DESCRIPTION
No need to work on references to references.