### PR TITLE
Update to Rocket 0.5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: clippy
       - run: cargo test --package askama_rocket --all-targets

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -506,7 +506,7 @@ impl<'a> Generator<'a> {
         let param = syn::GenericParam::Lifetime(syn::LifetimeDef::new(lifetime));
         self.write_header(
             buf,
-            "::askama_rocket::Responder<'askama>",
+            "::askama_rocket::Responder<'askama, 'askama>",
             Some(vec![param]),
         )?;
 

--- a/askama_rocket/Cargo.toml
+++ b/askama_rocket/Cargo.toml
@@ -14,7 +14,10 @@ edition = "2018"
 
 [dependencies]
 askama = { version = "0.11.2", path = "../askama", default-features = false, features = ["with-rocket", "mime", "mime_guess"] }
-rocket = { version = "0.4", default-features = false }
+rocket = { version = "0.5.0-rc.2", default-features = false }
+
+[dev-dependencies]
+futures-lite = "1.12.0"
 
 [features]
 default = ["askama/default"]

--- a/askama_rocket/src/lib.rs
+++ b/askama_rocket/src/lib.rs
@@ -14,6 +14,6 @@ pub fn respond<T: Template>(t: &T, _ext: &str) -> Result<'static> {
     let rsp = t.render().map_err(|_| Status::InternalServerError)?;
     Response::build()
         .header(Header::new("content-type", T::MIME_TYPE))
-        .sized_body(Cursor::new(rsp))
+        .sized_body(rsp.len(), Cursor::new(rsp))
         .ok()
 }


### PR DESCRIPTION
Though Rocket 0.5 still only a release candidate, Rocket 0.4 severely outdated, and depends on a bunch of crates with active security advisories. Rocket 0.5 updates its dependencies to fixes versions.

Also Rocket 0.4 needs a nightly Rust, which caused multiple problems.