### PR TITLE
[DONT MERGE] Always take reference when accessing value passed as argument to a macro

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -2034,7 +2034,7 @@ impl MapChain<'_, &str, LocalMeta> {
         let name = normalize_identifier(name);
         self.get(&name).map(|meta| match &meta.refs {
             Some(expr) => expr.clone(),
-            None => name.to_string(),
+            None => format!("&{name}"),
         })
     }
 

--- a/testing/templates/macro-iter.html.j2
+++ b/testing/templates/macro-iter.html.j2
@@ -1,0 +1,16 @@
+{%- macro list(list) -%}
+<ul>
+	{%- for item in list %}
+	<li>{{item}}</li>
+	{%- endfor %}
+</ul>
+<ol>
+	{%- for item in list %}
+	<li>{{item}}</li>
+	{%- endfor %}
+</ol>
+{%- endmacro -%}
+
+{%- for foo in foos %}
+{% call list(foo.list) %}
+{%- endfor %}

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -1,4 +1,5 @@
 use askama::Template;
+use std::collections::BTreeSet;
 
 #[derive(Template)]
 #[template(path = "macro.html")]
@@ -72,4 +73,14 @@ struct StrCmpTemplate;
 fn str_cmp() {
     let t = StrCmpTemplate;
     assert_eq!(t.render().unwrap(), "AfooBotherCneitherD");
+}
+
+#[derive(Template)]
+#[template(path = "macro-iter.html.j2")]
+struct MacroIterTemplate {
+    foos: Vec<Foo>,
+}
+
+struct Foo {
+    list: BTreeSet<String>,
 }


### PR DESCRIPTION
This was proposed by @djc to fix #708 - but just blindly taking references does not seem to work