### PR TITLE
Remove `_ext` from `askama_hyper`, too

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -445,8 +445,7 @@ impl<'a> Generator<'a> {
             "{} {{",
             quote!(fn from(value: &#ident #orig_ty_generics) -> Self)
         ))?;
-        let ext = self.input.extension().unwrap_or("txt");
-        buf.writeln(&format!("::askama_hyper::respond(value, {:?})", ext))?;
+        buf.writeln("::askama_hyper::respond(value)")?;
         buf.writeln("}")?;
         buf.writeln("}")
     }

--- a/askama_hyper/src/lib.rs
+++ b/askama_hyper/src/lib.rs
@@ -7,7 +7,7 @@ pub use askama::*;
 pub use hyper;
 use hyper::{header, Body, Response, StatusCode};
 
-pub fn try_respond<T: Template>(t: &T, _ext: &str) -> Result<Response<Body>> {
+pub fn try_respond<T: Template>(t: &T) -> Result<Response<Body>> {
     Response::builder()
         .status(StatusCode::OK)
         .header(
@@ -18,8 +18,8 @@ pub fn try_respond<T: Template>(t: &T, _ext: &str) -> Result<Response<Body>> {
         .map_err(|err| Error::Custom(Box::new(err)))
 }
 
-pub fn respond<T: Template>(t: &T, _ext: &str) -> Response<Body> {
-    match try_respond(t, _ext) {
+pub fn respond<T: Template>(t: &T) -> Response<Body> {
+    match try_respond(t) {
         Ok(response) => response,
         Err(_) => Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
That part was missing from #632, because #632 came before #706, and I forgot to update the older PR.