### PR TITLE
Version bump in README and book

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ First, add the following to your crate's `Cargo.toml`:
 
 ```toml
 # in section [dependencies]
-askama = "0.10"
+askama = "0.11.2"
 
 ```
 

--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -340,7 +340,7 @@ The following filters can be enabled by requesting the respective feature in the
 
 ```
 [dependencies]
-askama = { version = "0.11.0", features = "serde-json" }
+askama = { version = "0.11.2", features = "serde-json" }
 ```
 
 ### `json` | `tojson`

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -4,7 +4,7 @@ First, add the following to your crate's `Cargo.toml`:
 
 ```toml
 # in section [dependencies]
-askama = "0.8"
+askama = "0.11.2"
 
 ```
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -12,7 +12,7 @@ serde-json = ["serde_json", "askama/serde-json"]
 markdown = ["comrak", "askama/markdown"]
 
 [dependencies]
-askama = { path = "../askama", version = "0.11.0-beta.1" }
+askama = { path = "../askama", version = "0.11.2" }
 comrak = { version = "0.14", default-features = false, optional = true }
 serde_json = { version = "1.0", optional = true }
 


### PR DESCRIPTION
I was going through the book when I saw the version was still 0.8.

This commit ensures all references to Askama version are to 0.11.2. Most of them already were.

Merge whenever appropriate for release, #722 related