### PR TITLE
Fix some minor issues in escape documentation.

### DIFF
--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -59,11 +59,14 @@ where
     Ok(MarkupDisplay::new_safe(v, e))
 }
 
-/// Escapes `&`, `<` and `>` in strings
+/// Escapes strings according to the escape mode.
 ///
 /// Askama will automatically insert the first (`Escaper`) argument,
 /// so this filter only takes a single argument of any type that implements
 /// `Display`.
+///
+/// It is possible to optionally specify an escaper other than the default for
+/// the template's extension, like `{{ val|escape("txt") }}`.
 pub fn escape<E, T>(e: E, v: T) -> Result<MarkupDisplay<E, T>>
 where
     E: Escaper,

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -155,12 +155,12 @@ or `xml`. When specifying a template as `source` in an attribute, the
 you can specify an escape mode explicitly for your template by setting
 the `escape` attribute parameter value (to `none` or `html`).
 
-Askama escapes `<`, `>`, `&`, `"`, `'`, `\` and `/`, according to the
+Askama escapes `<`, `>`, `&`, `"`, and `'`, according to the
 [OWASP escaping recommendations][owasp]. Use the `safe` filter to
 prevent escaping for a single expression, or the `escape` (or `e`)
 filter to escape a single expression in an unescaped context.
 
-[owasp]: https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content
+[owasp]: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-for-html-contexts
 
 ```rust
 #[derive(Template)]


### PR DESCRIPTION
 - Remove forward slash and backslash from the list of escaped characters in the book since they [aren't escaped](https://github.com/djc/askama/blob/1b18bab91ba773425e521abc276a1278e0d61f3c/askama_escape/src/lib.rs#L126-L130)
 - Update the OWASP link, which used to include forward slash in the list of recommended escapes, but no longer does (askama's HTML escaper currently matches the OWASP example)
 - Update the `escape` filter documentation to remove the incomplete list of escaped characters.
 - Add example for specifying alternate escaper to `escape` filter documentation.