### PR TITLE
bump axum-core

### DIFF
--- a/askama_axum/Cargo.toml
+++ b/askama_axum/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 askama = { version = "0.11.2", path = "../askama", default-features = false, features = ["with-axum", "mime", "mime_guess"] }
-axum-core = "0.2"
+axum-core = "0.2.8"
 http = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
running `cargo audit` I got this:
Crate:     axum-core
Version:   0.1.2
Title:     No default limit put on request bodies
Date:      2022-08-31
ID:        RUSTSEC-2022-0055
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0055
Solution:  Upgrade to >=0.2.8, <0.3.0-rc.1 OR >=0.3.0-rc.2
Dependency tree: