### PR TITLE
Allow inserting arbitrary code

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -662,6 +662,12 @@ impl<'a> Generator<'a> {
                     self.write_buf_writable(buf)?;
                     buf.writeln("continue;")?;
                 }
+                Node::Code(ws, code) => {
+                    self.handle_ws(ws);
+                    self.write_buf_writable(buf)?;
+                    buf.buf.push_str(code);
+                    buf.buf.push('\n');
+                }
             }
         }
 

--- a/testing/tests/code_blocks.rs
+++ b/testing/tests/code_blocks.rs
@@ -60,8 +60,12 @@ fn test_code4_trim() {
 #[test]
 fn test_inser_percents() {
     #[derive(Template)]
-    #[template(source = r#"< {%%%%% writer.write_str("%%%")?; %%%%%} >"#, ext = "txt")]
+    #[template(
+        // one less '%' than in the delimiter '%%%%%'
+        source = r#"< {%%%%% writer.write_str("%%%%}")?; %%%%%} >"#,
+        ext = "txt"
+    )]
     struct Code;
 
-    assert_eq!(Code.render().unwrap(), "< %%% >");
+    assert_eq!(Code.render().unwrap(), "< %%%%} >");
 }

--- a/testing/tests/code_blocks.rs
+++ b/testing/tests/code_blocks.rs
@@ -1,0 +1,67 @@
+use askama::Template;
+
+#[test]
+fn test_code1() {
+    #[derive(Template)]
+    #[template(source = "<\n{%% writer.write_str(self.0)?; %%}\n>", ext = "txt")]
+    struct Code<'a>(&'a str);
+
+    assert_eq!(Code("Hello").render().unwrap(), "<\nHello\n>");
+}
+
+#[test]
+fn test_code1_trim_start() {
+    #[derive(Template)]
+    #[template(source = "<\n{%%- writer.write_str(self.0)?; %%}\n>", ext = "txt")]
+    struct Code<'a>(&'a str);
+
+    assert_eq!(Code("Hello").render().unwrap(), "<Hello\n>");
+}
+
+#[test]
+fn test_code1_trim_end() {
+    #[derive(Template)]
+    #[template(source = "<\n{%% writer.write_str(self.0)?; -%%}\n>", ext = "txt")]
+    struct Code<'a>(&'a str);
+
+    assert_eq!(Code("Hello").render().unwrap(), "<\nHello>");
+}
+
+#[test]
+fn test_code1_trim() {
+    #[derive(Template)]
+    #[template(source = "<\n{%%- writer.write_str(self.0)?; -%%}\n>", ext = "txt")]
+    struct Code<'a>(&'a str);
+
+    assert_eq!(Code("Hello").render().unwrap(), "<Hello>");
+}
+
+#[test]
+fn test_code4() {
+    #[derive(Template)]
+    #[template(source = "<\n{%%%%% writer.write_str(self.0)?; %%%%%}\n>", ext = "txt")]
+    struct Code<'a>(&'a str);
+
+    assert_eq!(Code("Hello").render().unwrap(), "<\nHello\n>");
+}
+
+#[test]
+fn test_code4_trim() {
+    #[derive(Template)]
+    #[template(
+        source = "<\n{%%%%%- writer.write_str(self.0)?; -%%%%%}\n>",
+        ext = "txt"
+    )]
+    struct Code<'a>(&'a str);
+
+    assert_eq!(Code("Hello").render().unwrap(), "<Hello>");
+}
+
+#[test]
+fn test_inser_percents() {
+    #[derive(Template)]
+    #[template(source = r#"< {%%%%% writer.write_str("%%%")?; %%%%%} >"#, ext = "txt")]
+    struct Code;
+
+    assert_eq!(Code.render().unwrap(), "< %%% >");
+}


### PR DESCRIPTION
This can be used in any cases when Askama's built-in features are too restrictive for a very special corner case, e.g. to `use` some library. It should be used seldom, e.g. for prototyping before you clean up your code.

Resolves #682.