### PR TITLE
Update `toml` dependency

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.58"
 proc-macro = true
 
 [features]
-config = ["serde", "toml"]
+config = ["serde", "toml_edit"]
 humansize = []
 markdown = []
 urlencode = []
@@ -38,4 +38,4 @@ proc-macro2 = "1"
 quote = "1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 syn = "1"
-toml = { version = "0.5", optional = true }
+toml_edit = { version = "0.19", optional = true, features = ["serde"] }

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -192,7 +192,8 @@ struct RawConfig {
 impl RawConfig {
     #[cfg(feature = "config")]
     fn from_toml_str(s: &str) -> std::result::Result<RawConfig, CompileError> {
-        toml::from_str(s).map_err(|e| format!("invalid TOML in {CONFIG_FILE_NAME}: {e}").into())
+        toml_edit::de::from_str(s)
+            .map_err(|e| format!("invalid TOML in {CONFIG_FILE_NAME}: {e}").into())
     }
 
     #[cfg(not(feature = "config"))]

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -44,7 +44,7 @@ pub(crate) struct Context<'a> {
 
 impl Context<'_> {
     pub(crate) fn new<'n>(
-        config: &Config<'_>,
+        config: &Config,
         path: &Path,
         nodes: &'n [Node<'n>],
     ) -> Result<Context<'n>, CompileError> {

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -9,8 +9,8 @@ use mime::Mime;
 
 pub(crate) struct TemplateInput<'a> {
     pub(crate) ast: &'a syn::DeriveInput,
-    pub(crate) config: &'a Config<'a>,
-    pub(crate) syntax: &'a Syntax<'a>,
+    pub(crate) config: &'a Config,
+    pub(crate) syntax: &'a Syntax,
     pub(crate) source: Source,
     pub(crate) print: Print,
     pub(crate) escaper: &'a str,
@@ -25,7 +25,7 @@ impl TemplateInput<'_> {
     /// `template()` attribute list fields.
     pub(crate) fn new<'n>(
         ast: &'n syn::DeriveInput,
-        config: &'n Config<'_>,
+        config: &'n Config,
         args: TemplateArgs,
     ) -> Result<TemplateInput<'n>, CompileError> {
         let TemplateArgs {
@@ -51,7 +51,7 @@ impl TemplateInput<'_> {
 
         // Validate syntax
         let syntax = syntax.map_or_else(
-            || Ok(config.syntaxes.get(config.default_syntax).unwrap()),
+            || Ok(config.syntaxes.get(&config.default_syntax).unwrap()),
             |s| {
                 config
                     .syntaxes

--- a/askama_derive/src/parser.rs
+++ b/askama_derive/src/parser.rs
@@ -250,15 +250,15 @@ fn keyword<'a>(k: &'a str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a str> {
 }
 
 struct State<'a> {
-    syntax: &'a Syntax<'a>,
+    syntax: &'a Syntax,
     loop_depth: Cell<usize>,
 }
 
 fn take_content<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
     let p_start = alt((
-        tag(s.syntax.block_start),
-        tag(s.syntax.comment_start),
-        tag(s.syntax.expr_start),
+        tag(s.syntax.block_start.as_str()),
+        tag(s.syntax.comment_start.as_str()),
+        tag(s.syntax.expr_start.as_str()),
     ));
 
     let (i, _) = not(eof)(i)?;
@@ -1162,8 +1162,8 @@ fn block_node<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
 fn block_comment_body<'a>(mut i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
     let mut level = 0;
     loop {
-        let (end, tail) = take_until(s.syntax.comment_end)(i)?;
-        match take_until::<_, _, Error<_>>(s.syntax.comment_start)(i) {
+        let (end, tail) = take_until(s.syntax.comment_end.as_str())(i)?;
+        match take_until::<_, _, Error<_>>(s.syntax.comment_start.as_str())(i) {
             Ok((start, _)) if start.as_ptr() < end.as_ptr() => {
                 level += 1;
                 i = &start[2..];
@@ -1209,28 +1209,25 @@ fn parse_template<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Vec<Node<'a
 }
 
 fn tag_block_start<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.block_start)(i)
+    tag(s.syntax.block_start.as_str())(i)
 }
 fn tag_block_end<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.block_end)(i)
+    tag(s.syntax.block_end.as_str())(i)
 }
 fn tag_comment_start<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.comment_start)(i)
+    tag(s.syntax.comment_start.as_str())(i)
 }
 fn tag_comment_end<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.comment_end)(i)
+    tag(s.syntax.comment_end.as_str())(i)
 }
 fn tag_expr_start<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.expr_start)(i)
+    tag(s.syntax.expr_start.as_str())(i)
 }
 fn tag_expr_end<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.expr_end)(i)
+    tag(s.syntax.expr_end.as_str())(i)
 }
 
-pub(crate) fn parse<'a>(
-    src: &'a str,
-    syntax: &'a Syntax<'a>,
-) -> Result<Vec<Node<'a>>, CompileError> {
+pub(crate) fn parse<'a>(src: &'a str, syntax: &'a Syntax) -> Result<Vec<Node<'a>>, CompileError> {
     let state = State {
         syntax,
         loop_depth: Cell::new(0),
@@ -1498,8 +1495,8 @@ mod tests {
     #[test]
     fn change_delimiters_parse_filter() {
         let syntax = Syntax {
-            expr_start: "{=",
-            expr_end: "=}",
+            expr_start: "{=".to_owned(),
+            expr_end: "=}".to_owned(),
             ..Syntax::default()
         };
 


### PR DESCRIPTION
This PR replaces `toml` by `toml_edit`. Since version 0.6, `toml` is a wrapper around `toml_edit`, and the more basic library already meets our needs.

Also the configuration is made `'static`, because `toml` and `toml_edit` both needs to implement serde's `DeserializeOwned` by now. We allocate the strings once per template, so it is very unlikely that this change will have any measurable impact, neither in compile time nor RAM usage.