### PR TITLE
Update `ui` test for trybuild 1.0.76

### DIFF
--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.4"
-trybuild = "1.0.55"
+trybuild = "1.0.76"
 version_check = "0.9"
 
 [[bench]]

--- a/testing/tests/ui/since_1.58/incorrect_path.stderr
+++ b/testing/tests/ui/since_1.58/incorrect_path.stderr
@@ -1,4 +1,4 @@
-error: template "thisdoesnotexist.html" not found in directories ["$WORKSPACE/target/tests/askama_testing/templates"]
+error: template "thisdoesnotexist.html" not found in directories ["$WORKSPACE/target/tests/trybuild/askama_testing/templates"]
  --> tests/ui/since_1.58/incorrect_path.rs:3:10
   |
 3 | #[derive(Template)]


### PR DESCRIPTION
In <https://github.com/dtolnay/trybuild/pull/219> the output of error messages was subtly changed, because they introduced a subdirectoy in their temp path.

This PR fixes the mismatch between the expected and the actual output.