### PR TITLE
Apply clippy suggestions for 1.67

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 readme = "../README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/askama/src/error.rs
+++ b/askama/src/error.rs
@@ -56,10 +56,10 @@ impl std::error::Error for Error {
 impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Fmt(err) => write!(formatter, "formatting error: {}", err),
-            Error::Custom(err) => write!(formatter, "{}", err),
+            Error::Fmt(err) => write!(formatter, "formatting error: {err}"),
+            Error::Custom(err) => write!(formatter, "{err}"),
             #[cfg(feature = "serde_json")]
-            Error::Json(err) => write!(formatter, "json conversion error: {}", err),
+            Error::Json(err) => write!(formatter, "json conversion error: {err}"),
             #[cfg(feature = "serde_yaml")]
             Error::Yaml(err) => write!(formatter, "yaml conversion error: {}", err),
         }

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -163,7 +163,7 @@ pub fn linebreaks<T: fmt::Display>(s: T) -> Result<String> {
     let s = s.to_string();
     let linebroken = s.replace("\n\n", "</p><p>").replace('\n', "<br/>");
 
-    Ok(format!("<p>{}</p>", linebroken))
+    Ok(format!("<p>{linebroken}</p>"))
 }
 
 /// Converts all newlines in a piece of plain text to HTML line breaks
@@ -181,7 +181,7 @@ pub fn paragraphbreaks<T: fmt::Display>(s: T) -> Result<String> {
     let s = s.to_string();
     let linebroken = s.replace("\n\n", "</p><p>").replace("<p></p>", "");
 
-    Ok(format!("<p>{}</p>", linebroken))
+    Ok(format!("<p>{linebroken}</p>"))
 }
 
 /// Converts to lowercase
@@ -279,7 +279,7 @@ where
             rv.push_str(separator);
         }
 
-        write!(rv, "{}", item)?;
+        write!(rv, "{item}")?;
     }
 
     Ok(rv)

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -93,7 +93,7 @@ pub trait Template: fmt::Display {
     /// Renders the template to the given `writer` io buffer
     #[inline]
     fn write_into(&self, writer: &mut (impl std::io::Write + ?Sized)) -> std::io::Result<()> {
-        writer.write_fmt(format_args!("{}", self))
+        writer.write_fmt(format_args!("{self}"))
     }
 
     /// The template's extension, if provided
@@ -140,7 +140,7 @@ impl<T: Template> DynTemplate for T {
 
     #[inline]
     fn dyn_write_into(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
-        writer.write_fmt(format_args!("{}", self))
+        writer.write_fmt(format_args!("{self}"))
     }
 
     fn extension(&self) -> Option<&'static str> {
@@ -201,7 +201,7 @@ mod tests {
 
         assert_eq!(test.to_string(), "test");
 
-        assert_eq!(format!("{}", test), "test");
+        assert_eq!(format!("{test}"), "test");
 
         let mut vec = Vec::new();
         test.dyn_write_into(&mut vec).unwrap();

--- a/askama_actix/Cargo.toml
+++ b/askama_actix/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 actix-web = { version = "4", default-features = false }

--- a/askama_axum/Cargo.toml
+++ b/askama_axum/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "askama_axum"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 description = "Axum integration for Askama templates"
 keywords = ["markup", "template", "jinja2", "html", "axum"]
 categories = ["template-engine"]

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -7,7 +7,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT/Apache-2.0"
 workspace = ".."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [lib]
 proc-macro = true

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashSet};
-use std::convert::TryFrom;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
@@ -58,13 +57,13 @@ impl Config<'_> {
                     .insert(name.to_string(), Syntax::try_from(raw_s)?)
                     .is_some()
                 {
-                    return Err(format!("syntax \"{}\" is already defined", name).into());
+                    return Err(format!("syntax \"{name}\" is already defined").into());
                 }
             }
         }
 
         if !syntaxes.contains_key(default_syntax) {
-            return Err(format!("default syntax \"{}\" not found", default_syntax).into());
+            return Err(format!("default syntax \"{default_syntax}\" not found").into());
         }
 
         let mut escapers = Vec::new();
@@ -193,7 +192,7 @@ struct RawConfig<'d> {
 impl RawConfig<'_> {
     #[cfg(feature = "config")]
     fn from_toml_str(s: &str) -> std::result::Result<RawConfig<'_>, CompileError> {
-        toml::from_str(s).map_err(|e| format!("invalid TOML in {}: {}", CONFIG_FILE_NAME, e).into())
+        toml::from_str(s).map_err(|e| format!("invalid TOML in {CONFIG_FILE_NAME}: {e}").into())
     }
 
     #[cfg(not(feature = "config"))]

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -42,7 +42,7 @@ impl TemplateInput<'_> {
         // of `ext` is merged into a synthetic `path` value here.
         let source = source.expect("template path or source not found in attributes");
         let path = match (&source, &ext) {
-            (&Source::Path(ref path), _) => config.find_template(path, None)?,
+            (Source::Path(path), _) => config.find_template(path, None)?,
             (&Source::Source(_), Some(ext)) => PathBuf::from(format!("{}.{}", ast.ident, ext)),
             (&Source::Source(_), None) => {
                 return Err("must include 'ext' attribute when using 'source' attribute".into())
@@ -56,7 +56,7 @@ impl TemplateInput<'_> {
                 config
                     .syntaxes
                     .get(&s)
-                    .ok_or_else(|| CompileError::from(format!("attribute syntax {} not exist", s)))
+                    .ok_or_else(|| CompileError::from(format!("attribute syntax {s} not exist")))
             },
         )?;
 
@@ -78,7 +78,7 @@ impl TemplateInput<'_> {
         }
 
         let escaper = escaper.ok_or_else(|| {
-            CompileError::from(format!("no escaper defined for extension '{}'", escaping))
+            CompileError::from(format!("no escaper defined for extension '{escaping}'"))
         })?;
 
         let mime_type =
@@ -146,7 +146,7 @@ impl FromStr for Print {
             "ast" => Ast,
             "code" => Code,
             "none" => None,
-            v => return Err(format!("invalid value for print option: {}", v,).into()),
+            v => return Err(format!("invalid value for print option: {v}",).into()),
         })
     }
 }

--- a/askama_derive/src/parser.rs
+++ b/askama_derive/src/parser.rs
@@ -1238,7 +1238,7 @@ pub(crate) fn parse<'a>(
     match parse_template(src, &state) {
         Ok((left, res)) => {
             if !left.is_empty() {
-                Err(format!("unable to parse template:\n\n{:?}", left).into())
+                Err(format!("unable to parse template:\n\n{left:?}").into())
             } else {
                 Ok(res)
             }
@@ -1251,7 +1251,7 @@ pub(crate) fn parse<'a>(
 
             let source_after = match source_after.char_indices().enumerate().take(41).last() {
                 Some((40, (i, _))) => format!("{:?}...", &source_after[..i]),
-                _ => format!("{:?}", source_after),
+                _ => format!("{source_after:?}"),
             };
 
             let (row, last_line) = source_before.lines().enumerate().last().unwrap();

--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -56,8 +56,7 @@ where
                     fmt,
                     escaper: &self.escaper
                 },
-                "{}",
-                t
+                "{t}"
             ),
             DisplayValue::Safe(ref t) => t.fmt(fmt),
         }

--- a/askama_gotham/Cargo.toml
+++ b/askama_gotham/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 askama = { version = "0.11.2", path = "../askama", default-features = false, features = ["with-gotham", "mime", "mime_guess"] }

--- a/askama_hyper/Cargo.toml
+++ b/askama_hyper/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 askama = { version = "0.11.2", path = "../askama", default-features = false, features = ["with-hyper"] }

--- a/askama_hyper/tests/basic.rs
+++ b/askama_hyper/tests/basic.rs
@@ -43,7 +43,7 @@ async fn test_hyper() {
         server.await.expect("Could not serve");
     };
     let query = async move {
-        let uri = format!("http://{}/hello/world", local_addr)
+        let uri = format!("http://{local_addr}/hello/world")
             .parse()
             .expect("Could not format URI");
         let client = Client::new();

--- a/askama_mendes/Cargo.toml
+++ b/askama_mendes/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 askama = { version = "0.11.2", path = "../askama", default-features = false, features = ["with-mendes", "mime", "mime_guess"] }

--- a/askama_mendes/tests/basic.rs
+++ b/askama_mendes/tests/basic.rs
@@ -71,8 +71,8 @@ impl From<mendes::Error> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Askama(e) => write!(f, "{}", e),
-            Error::Mendes(e) => write!(f, "{}", e),
+            Error::Askama(e) => write!(f, "{e}"),
+            Error::Mendes(e) => write!(f, "{e}"),
         }
     }
 }

--- a/askama_rocket/Cargo.toml
+++ b/askama_rocket/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 askama = { version = "0.11.2", path = "../askama", default-features = false, features = ["with-rocket", "mime", "mime_guess"] }

--- a/askama_tide/Cargo.toml
+++ b/askama_tide/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "askama_tide"
 version = "0.14.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 description = "Tide integration for Askama templates"
 keywords = ["markup", "template", "html", "tide", "http-types"]
 homepage = "https://github.com/djc/askama"

--- a/askama_tide/tests/tide.rs
+++ b/askama_tide/tests/tide.rs
@@ -1,6 +1,5 @@
 use askama::Template;
 use async_std::prelude::*;
-use std::convert::TryInto;
 use tide::{http::mime::HTML, Body, Response};
 
 #[derive(Template)]

--- a/askama_warp/Cargo.toml
+++ b/askama_warp/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/djc/askama"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 askama = { version = "0.11.2", path = "../askama", default-features = false, features = ["with-warp", "mime", "mime_guess"] }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -3,7 +3,8 @@ name = "askama_testing"
 version = "0.1.0"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
+rust-version = "1.58"
 publish = false
 
 [features]

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -122,8 +122,7 @@ mod filters {
     }
     // for test_nested_filter_ref
     pub fn mytrim(s: &dyn (::std::fmt::Display)) -> ::askama::Result<String> {
-        let s = format!("{}", s);
-        Ok(s.trim().to_owned())
+        Ok(s.to_string().trim().to_owned())
     }
 }
 

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -311,14 +311,14 @@ struct FunctionRefTemplate {
 #[test]
 fn test_func_ref_call() {
     let t = FunctionRefTemplate {
-        world: |s, r| format!("world({}, {})", s, r),
+        world: |s, r| format!("world({s}, {r})"),
     };
     assert_eq!(t.render().unwrap(), "Hello, world(123, 4)!");
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn world2(s: &str, v: u8) -> String {
-    format!("world{}{}", v, s)
+    format!("world{v}{s}")
 }
 
 #[derive(Template)]
@@ -346,7 +346,7 @@ struct FunctionTemplate;
 impl FunctionTemplate {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     fn world3(&self, s: &str, v: u8) -> String {
-        format!("world{}{}", s, v)
+        format!("world{s}{v}")
     }
 }
 


### PR DESCRIPTION
Set an explicit `rust-version` to avoid further clippy-induced MSRV bumps.