### PR TITLE
derive: Shrink dependency list

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -34,8 +34,7 @@ with-warp = []
 mime = "0.3"
 mime_guess = "2"
 nom = "7"
-proc-macro2 = "1"
-quote = "1"
+quote = { version = "1", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-syn = "1"
+syn = { version = "1", default-features = false }
 toml_edit = { version = "0.19", optional = true, features = ["serde"] }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -463,7 +463,7 @@ impl<'a> Generator<'a> {
         let mut where_clause = match where_clause {
             Some(clause) => clause.clone(),
             None => syn::WhereClause {
-                where_token: syn::Token![where](proc_macro2::Span::call_site()),
+                where_token: syn::token::Where::default(),
                 predicates: syn::punctuated::Punctuated::new(),
             },
         };
@@ -500,8 +500,7 @@ impl<'a> Generator<'a> {
     // Implement Rocket's `Responder`.
     #[cfg(feature = "with-rocket")]
     fn impl_rocket_responder(&mut self, buf: &mut Buffer) -> Result<(), CompileError> {
-        let lifetime = syn::Lifetime::new("'askama", proc_macro2::Span::call_site());
-        let param = syn::GenericParam::Lifetime(syn::LifetimeDef::new(lifetime));
+        let param = syn::parse_quote!('askama);
         self.write_header(
             buf,
             "::askama_rocket::Responder<'askama, 'askama>",


### PR DESCRIPTION
We don't need the more advanced features that `quote` and `syn` offer. This PR opts out of using them.

Until <https://github.com/rust-lang/rust/issues/92565> is resolved, we cannot give a better error location than `#[derive(Template)]` itself. So we don't need to keep track of the span in our `struct CompileError`, and we can remove the dependency of `proc_macro2`.