### PR TITLE
Replace `toml_edit` with `basic-toml`

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.58"
 proc-macro = true
 
 [features]
-config = ["serde", "toml_edit"]
+config = ["serde", "basic-toml"]
 humansize = []
 markdown = []
 urlencode = []
@@ -38,4 +38,4 @@ proc-macro2 = "1"
 quote = "1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 syn = "1"
-toml_edit = { version = "0.19", optional = true, features = ["serde"] }
+basic-toml = { version = "0.1.1", optional = true }

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -192,7 +192,7 @@ struct RawConfig {
 impl RawConfig {
     #[cfg(feature = "config")]
     fn from_toml_str(s: &str) -> std::result::Result<RawConfig, CompileError> {
-        toml_edit::de::from_str(s)
+        basic_toml::from_str(s)
             .map_err(|e| format!("invalid TOML in {CONFIG_FILE_NAME}: {e}").into())
     }
 

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -44,7 +44,7 @@ pub(crate) struct Context<'a> {
 
 impl Context<'_> {
     pub(crate) fn new<'n>(
-        config: &Config,
+        config: &Config<'_>,
         path: &Path,
         nodes: &'n [Node<'n>],
     ) -> Result<Context<'n>, CompileError> {

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -9,8 +9,8 @@ use mime::Mime;
 
 pub(crate) struct TemplateInput<'a> {
     pub(crate) ast: &'a syn::DeriveInput,
-    pub(crate) config: &'a Config,
-    pub(crate) syntax: &'a Syntax,
+    pub(crate) config: &'a Config<'a>,
+    pub(crate) syntax: &'a Syntax<'a>,
     pub(crate) source: Source,
     pub(crate) print: Print,
     pub(crate) escaper: &'a str,
@@ -25,7 +25,7 @@ impl TemplateInput<'_> {
     /// `template()` attribute list fields.
     pub(crate) fn new<'n>(
         ast: &'n syn::DeriveInput,
-        config: &'n Config,
+        config: &'n Config<'_>,
         args: TemplateArgs,
     ) -> Result<TemplateInput<'n>, CompileError> {
         let TemplateArgs {
@@ -51,7 +51,7 @@ impl TemplateInput<'_> {
 
         // Validate syntax
         let syntax = syntax.map_or_else(
-            || Ok(config.syntaxes.get(&config.default_syntax).unwrap()),
+            || Ok(config.syntaxes.get(config.default_syntax).unwrap()),
             |s| {
                 config
                     .syntaxes

--- a/askama_derive/src/parser/mod.rs
+++ b/askama_derive/src/parser/mod.rs
@@ -22,12 +22,12 @@ mod node;
 mod tests;
 
 struct State<'a> {
-    syntax: &'a Syntax,
+    syntax: &'a Syntax<'a>,
     loop_depth: Cell<usize>,
 }
 
-impl State<'_> {
-    fn new(syntax: &Syntax) -> State<'_> {
+impl<'a> State<'a> {
+    fn new(syntax: &'a Syntax<'a>) -> State<'a> {
         State {
             syntax,
             loop_depth: Cell::new(0),
@@ -58,7 +58,10 @@ impl From<char> for Whitespace {
     }
 }
 
-pub(crate) fn parse<'a>(src: &'a str, syntax: &'a Syntax) -> Result<Vec<Node<'a>>, CompileError> {
+pub(crate) fn parse<'a>(
+    src: &'a str,
+    syntax: &'a Syntax<'_>,
+) -> Result<Vec<Node<'a>>, CompileError> {
     match Node::parse(src, &State::new(syntax)) {
         Ok((left, res)) => {
             if !left.is_empty() {
@@ -271,9 +274,9 @@ fn path(i: &str) -> IResult<&str, Vec<&str>> {
 
 fn take_content<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
     let p_start = alt((
-        tag(s.syntax.block_start.as_str()),
-        tag(s.syntax.comment_start.as_str()),
-        tag(s.syntax.expr_start.as_str()),
+        tag(s.syntax.block_start),
+        tag(s.syntax.comment_start),
+        tag(s.syntax.expr_start),
     ));
 
     let (i, _) = not(eof)(i)?;
@@ -290,25 +293,25 @@ fn take_content<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
 }
 
 fn tag_block_start<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.block_start.as_str())(i)
+    tag(s.syntax.block_start)(i)
 }
 
 fn tag_block_end<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.block_end.as_str())(i)
+    tag(s.syntax.block_end)(i)
 }
 
 fn tag_comment_start<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.comment_start.as_str())(i)
+    tag(s.syntax.comment_start)(i)
 }
 
 fn tag_comment_end<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.comment_end.as_str())(i)
+    tag(s.syntax.comment_end)(i)
 }
 
 fn tag_expr_start<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.expr_start.as_str())(i)
+    tag(s.syntax.expr_start)(i)
 }
 
 fn tag_expr_end<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
-    tag(s.syntax.expr_end.as_str())(i)
+    tag(s.syntax.expr_end)(i)
 }

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -520,8 +520,8 @@ fn block_node<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
 fn block_comment_body<'a>(mut i: &'a str, s: &State<'_>) -> IResult<&'a str, &'a str> {
     let mut level = 0;
     loop {
-        let (end, tail) = take_until(s.syntax.comment_end.as_str())(i)?;
-        match take_until::<_, _, Error<_>>(s.syntax.comment_start.as_str())(i) {
+        let (end, tail) = take_until(s.syntax.comment_end)(i)?;
+        match take_until::<_, _, Error<_>>(s.syntax.comment_start)(i) {
             Ok((start, _)) if start.as_ptr() < end.as_ptr() => {
                 level += 1;
                 i = &start[2..];

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -224,8 +224,8 @@ fn test_parse_root_path() {
 #[test]
 fn change_delimiters_parse_filter() {
     let syntax = Syntax {
-        expr_start: "{=".to_owned(),
-        expr_end: "=}".to_owned(),
+        expr_start: "{=",
+        expr_end: "=}",
         ..Syntax::default()
     };
 


### PR DESCRIPTION
This removes a bunch of transitive dependencies (e.g. "nom8`), and we can use borrowed strings again.