### PR TITLE
Propogate size_hint from sub-blocks

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -630,16 +630,16 @@ impl<'a> Generator<'a> {
                     self.write_let(buf, ws, var, val)?;
                 }
                 Node::Cond(ref conds, ws) => {
-                    self.write_cond(ctx, buf, conds, ws)?;
+                    size_hint += self.write_cond(ctx, buf, conds, ws)?;
                 }
                 Node::Match(ws1, ref expr, ref arms, ws2) => {
-                    self.write_match(ctx, buf, ws1, expr, arms, ws2)?;
+                    size_hint += self.write_match(ctx, buf, ws1, expr, arms, ws2)?;
                 }
                 Node::Loop(ref loop_block) => {
-                    self.write_loop(ctx, buf, loop_block)?;
+                    size_hint += self.write_loop(ctx, buf, loop_block)?;
                 }
                 Node::BlockDef(ws1, name, _, ws2) => {
-                    self.write_block(buf, Some(name), Ws(ws1.0, ws2.1))?;
+                    size_hint += self.write_block(buf, Some(name), Ws(ws1.0, ws2.1))?;
                 }
                 Node::Include(ws, path) => {
                     size_hint += self.handle_include(ctx, buf, ws, path)?;

--- a/testing/templates/size-child-super.txt
+++ b/testing/templates/size-child-super.txt
@@ -1,0 +1,2 @@
+{% extends "size-parent.txt" %}
+{% block main %}{% call super() %}{% endblock %}

--- a/testing/templates/size-child.txt
+++ b/testing/templates/size-child.txt
@@ -1,0 +1,2 @@
+{% extends "size-parent.txt" %}
+{% block main %}{% if true %}123{% endif %}{% endblock %}

--- a/testing/templates/size-parent.txt
+++ b/testing/templates/size-parent.txt
@@ -1,0 +1,1 @@
+{% block main %}{% if true %}12345{% endif %}{% endblock %}

--- a/testing/tests/size_hint.rs
+++ b/testing/tests/size_hint.rs
@@ -1,0 +1,47 @@
+use askama::Template;
+
+macro_rules! test_size {
+    ($source:literal, $expected:expr) => {{
+        #[derive(Template)]
+        #[template(source = $source, ext = "txt")]
+        struct T(bool);
+
+        assert_eq!(T::SIZE_HINT, $expected);
+    }};
+}
+
+#[test]
+fn test_cond_size_hint() {
+    test_size!("{% if self.0 %}12345{% else %}12345{% endif %}", 10);
+}
+
+#[test]
+fn test_match_size_hint() {
+    test_size!(
+        "{% match self.0 %}{% when true %}12345{% else %}12345{% endmatch %}",
+        5
+    );
+}
+
+#[test]
+fn test_loop_size_hint() {
+    test_size!("{% for i in 0..1 %}12345{% endfor %}", 7);
+}
+
+#[test]
+fn test_block_size_hint() {
+    #[derive(Template)]
+    #[template(path = "size-child.txt")]
+    struct T;
+
+    assert_eq!(T::SIZE_HINT, 3);
+}
+
+#[test]
+fn test_super_size_hint() {
+    #[derive(Template)]
+    #[template(path = "size-child-super.txt")]
+    struct T;
+
+    assert_eq!(T::SIZE_HINT, 5);
+}


### PR DESCRIPTION
I've opened this based on the assumption that #786 is a simple oversight, and added test cases to catch it.  The values in those assertions were simply blessed on the first run of the test.