### PR TITLE
Add whitespace argument in template derive proc-macro

### DIFF
--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -549,4 +549,34 @@ mod tests {
         .unwrap();
         assert_eq!(config.whitespace, WhitespaceHandling::Minimize);
     }
+
+    #[cfg(feature = "toml")]
+    #[test]
+    fn test_whitespace_in_template() {
+        // Checking that template arguments have precedence over general configuration.
+        // So in here, in the template arguments, there is `whitespace = "minimize"` so
+        // the `WhitespaceHandling` should be `Minimize` as well.
+        let config = Config::new(
+            r#"
+            [general]
+            whitespace = "suppress"
+            "#,
+            Some(&"minimize".to_owned()),
+        )
+        .unwrap();
+        assert_eq!(config.whitespace, WhitespaceHandling::Minimize);
+
+        let config = Config::new(r#""#, Some(&"minimize".to_owned())).unwrap();
+        assert_eq!(config.whitespace, WhitespaceHandling::Minimize);
+    }
+
+    #[test]
+    fn test_config_whitespace_error() {
+        let config = Config::new(r#""#, Some(&"trim".to_owned()));
+        if let Err(err) = config {
+            assert_eq!(err.msg, "invalid value for `whitespace`: \"trim\"");
+        } else {
+            panic!("Config::new should have return an error");
+        }
+    }
 }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -30,7 +30,7 @@ pub(crate) fn derive_template(input: TokenStream) -> TokenStream {
 fn build_template(ast: &syn::DeriveInput) -> Result<String, CompileError> {
     let template_args = TemplateArgs::new(ast)?;
     let config_toml = read_config_file(template_args.config_path.as_deref())?;
-    let config = Config::new(&config_toml)?;
+    let config = Config::new(&config_toml, template_args.whitespace.as_ref())?;
     let input = TemplateInput::new(ast, &config, template_args)?;
     let source: String = match input.source {
         Source::Source(ref s) => s.clone(),
@@ -83,6 +83,7 @@ pub(crate) struct TemplateArgs {
     pub(crate) ext: Option<String>,
     pub(crate) syntax: Option<String>,
     pub(crate) config_path: Option<String>,
+    pub(crate) whitespace: Option<String>,
 }
 
 impl TemplateArgs {
@@ -180,6 +181,12 @@ impl TemplateArgs {
                     args.config_path = Some(s.value())
                 } else {
                     return Err("config value must be string literal".into());
+                }
+            } else if ident == "whitespace" {
+                if let syn::Lit::Str(ref s) = pair.lit {
+                    args.whitespace = Some(s.value())
+                } else {
+                    return Err("whitespace value must be string literal".into());
                 }
             } else {
                 return Err(format!("unsupported attribute key {ident:?} found").into());

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -57,6 +57,20 @@ character remaining will be a newline.
 If you want this to be the default behaviour, you can set `whitespace` to
 `"minimize"`.
 
+To be noted: you can also configure `whitespace` directly into the `template`
+derive proc macro:
+
+```rust
+#[derive(Template)]
+#[template(whitespace = "suppress")]
+pub struct SomeTemplate;
+```
+
+If you configure `whitespace` directly into the `template` derive proc-macro,
+it will take precedence over the one in your configuration file. So in this
+case, if you already set `whitespace = "minimize` into your configuration file,
+it will be replaced by `suppress` for this template.
+
 ## Custom syntaxes
 
 Here is an example that defines two custom syntaxes:

--- a/testing/tests/whitespace.rs
+++ b/testing/tests/whitespace.rs
@@ -84,3 +84,27 @@ fn test_minimize_whitespace() {
     );
     test_template!(" \n1 \n{%~  if true  ~%} 2 {%~  endif  ~%}3 ", " \n1\n 2 3");
 }
+
+macro_rules! test_template_ws_config {
+    ($config:literal, $ws:literal, $source:literal, $rendered: literal) => {{
+        #[derive(Template)]
+        #[template(source = $source, ext = "txt", config = $config, whitespace = $ws)]
+        struct CondWs;
+
+        assert_eq!(CondWs.render().unwrap(), $rendered);
+    }};
+}
+
+#[test]
+fn test_template_whitespace_config() {
+    test_template_ws_config!("test_trim.toml", "preserve", "\t1{# #}\t2", "\t1\t2");
+    test_template_ws_config!("test_trim.toml", "minimize", " 1{# #}  2", " 1 2");
+    test_template_ws_config!("test_trim.toml", "suppress", " 1{# #}  2", " 12");
+    test_template_ws_config!(
+        "test_minimize.toml",
+        "preserve",
+        "\n1{# #}\n\n\n2",
+        "\n1\n\n\n2"
+    );
+    test_template_ws_config!("test_minimize.toml", "suppress", "\n1{# #}\n\n\n2", "\n12");
+}


### PR DESCRIPTION
This PR adds the possibility to set `whitespace = "..."` directly into the template derive proc-macro.