### PR TITLE
Version bump askama_derive to 0.12.1

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_derive"
-version = "0.12.0"
+version = "0.12.1"
 description = "Procedural macro package for Askama"
 homepage = "https://github.com/djc/askama"
 repository = "https://github.com/djc/askama"

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -130,6 +130,12 @@ impl TemplateArgs {
 
             let value = match pair.value {
                 syn::Expr::Lit(lit) => lit,
+                syn::Expr::Group(group) => match *group.expr {
+                    syn::Expr::Lit(lit) => lit,
+                    _ => {
+                        return Err(format!("unsupported argument value type for {ident:?}").into())
+                    }
+                },
                 _ => return Err(format!("unsupported argument value type for {ident:?}").into()),
             };
 


### PR DESCRIPTION
Since compiling two versions of syn is not cool, let's get this out (including a few other recent fixes).