### PR TITLE
Use `try_reserve()` instead of `with_capacity()`

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -82,7 +82,8 @@ pub use crate::error::{Error, Result};
 pub trait Template: fmt::Display {
     /// Helper method which allocates a new `String` and renders into it
     fn render(&self) -> Result<String> {
-        let mut buf = String::with_capacity(Self::SIZE_HINT);
+        let mut buf = String::new();
+        let _ = buf.try_reserve(Self::SIZE_HINT);
         self.render_into(&mut buf)?;
         Ok(buf)
     }


### PR DESCRIPTION
`String::with_capacity()` panics if the requested memory could not be allocated. `Template::render()` is a fallible method, and the fact that it can panic is not documented.

This commit uses `String::try_reserve()` instead, so even for an exceedingly large `SIZE_HINT` the method should not panic. In the generated code, `write!()` calls may fail with `Err(std::fmt::Error)` instead.

I do not test if `try_reserve()` returned an error, because the rendering might succeed anyway, if less bytes are written than estimated.