### PR TITLE
Updating the axum integration doc (issue #588)

### DIFF
--- a/book/src/integrations.md
+++ b/book/src/integrations.md
@@ -22,7 +22,7 @@ from the Askama test suite for more on how to integrate.
 
 ## Axum integration
 
-Enabling the `with-axum` feature appends an implementation of Axum's
+Enabling the `with-axum` feature and depending on the `askama_axum` crate appends an implementation of Axum's
 `IntoResponse` trait for each template type. This makes it easy to trivially
 return a value of that type in a Axum handler. See
 [the example](https://github.com/djc/askama/blob/main/askama_axum/tests/basic.rs)

--- a/book/src/integrations.md
+++ b/book/src/integrations.md
@@ -22,7 +22,7 @@ from the Askama test suite for more on how to integrate.
 
 ## Axum integration
 
-Enabling the `with-axum` feature and depending on the `askama_axum` crate appends an implementation of Axum's
+Depending on the `askama_axum` crate appends an implementation of Axum's
 `IntoResponse` trait for each template type. This makes it easy to trivially
 return a value of that type in a Axum handler. See
 [the example](https://github.com/djc/askama/blob/main/askama_axum/tests/basic.rs)


### PR DESCRIPTION
When using the askama feature "with-axum" you need to also depend on the "askama_axum" crate directly.