### PR TITLE
Escape HTML faster

### DIFF
--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -113,12 +113,20 @@ impl Escaper for Html {
     {
         let mut last = 0;
         for (index, byte) in string.bytes().enumerate() {
+            const MIN_CHAR: u8 = b'"';
+            const MAX_CHAR: u8 = b'>';
+            const TABLE: [Option<&&str>; (MAX_CHAR - MIN_CHAR + 1) as usize] = {
+                let mut table = [None; (MAX_CHAR - MIN_CHAR + 1) as usize];
+                table[(b'<' - MIN_CHAR) as usize] = Some(&"&lt;");
+                table[(b'>' - MIN_CHAR) as usize] = Some(&"&gt;");
+                table[(b'&' - MIN_CHAR) as usize] = Some(&"&amp;");
+                table[(b'"' - MIN_CHAR) as usize] = Some(&"&quot;");
+                table[(b'\'' - MIN_CHAR) as usize] = Some(&"&#x27;");
+                table
+            };
+
             let escaped = match byte {
-                b'<' => Some(&"&lt;"),
-                b'>' => Some(&"&gt;"),
-                b'&' => Some(&"&amp;"),
-                b'"' => Some(&"&quot;"),
-                b'\'' => Some(&"&#x27;"),
+                MIN_CHAR..=MAX_CHAR => TABLE[(byte - MIN_CHAR) as usize],
                 _ => None,
             };
             if let Some(escaped) = escaped {


### PR DESCRIPTION
Escaped HTML characters vary in length. So, in order to select the correct replacement two variables need to be loaded: The pointer to the new substring and its length. Because of this the generated code is less dense than it could be.

With this PR instead of selecting the appropriate `&str`, an `&&str` is selected. The former consumes two words while the latter consumes only one. Intuitively one might assume that the double dereference makes the code slower, but the optimized lookup seems to be so much faster, so that the change is worth its weight.

Comparing the result of `cargo bench` (best out of three runs for both):

```text
Old:  [4.3592 µs 4.3675 µs 4.3764 µs]
New:  [3.8691 µs 3.8766 µs 3.8860 µs]
Diff: [-11.24 %  -11.24 %  -12.21 % ]
```