### PR TITLE
Allow macros to be defined and called without arguments

### DIFF
--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -133,12 +133,13 @@ fn block_call(i: &str) -> IResult<&str, Node<'_>> {
         cut(tuple((
             opt(tuple((ws(identifier), ws(tag("::"))))),
             ws(identifier),
-            ws(Expr::parse_arguments),
+            opt(ws(Expr::parse_arguments)),
             opt(expr_handle_ws),
         ))),
     ));
     let (i, (pws, _, (scope, name, args, nws))) = p(i)?;
     let scope = scope.map(|(scope, _)| scope);
+    let args = args.unwrap_or_default();
     Ok((i, Node::Call(Ws(pws, nws), scope, name, args)))
 }
 
@@ -415,7 +416,7 @@ fn block_macro<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
         ws(keyword("macro")),
         cut(tuple((
             ws(identifier),
-            ws(parameters),
+            opt(ws(parameters)),
             opt(expr_handle_ws),
             |i| tag_block_end(i, s),
         ))),
@@ -434,6 +435,8 @@ fn block_macro<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
     let (i, (contents, (_, pws2, _, (_, nws2)))) = end(i)?;
 
     assert_ne!(name, "super", "invalid macro name 'super'");
+
+    let params = params.unwrap_or_default();
 
     Ok((
         i,

--- a/testing/templates/macro-no-args.html
+++ b/testing/templates/macro-no-args.html
@@ -1,0 +1,21 @@
+1
+
+{%- macro empty -%}
+the best thing
+{%- endmacro -%}
+
+1
+
+{%- call empty() -%}
+
+1
+
+{%- macro whole() -%}
+we've ever done
+{%- endmacro -%}
+
+11
+
+{%- call whole -%}
+
+11

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -13,6 +13,16 @@ fn test_macro() {
 }
 
 #[derive(Template)]
+#[template(path = "macro-no-args.html")]
+struct MacroNoArgsTemplate;
+
+#[test]
+fn test_macro_no_args() {
+    let t = MacroNoArgsTemplate;
+    assert_eq!(t.render().unwrap(), "11the best thing111we've ever done11");
+}
+
+#[derive(Template)]
 #[template(path = "import.html")]
 struct ImportTemplate<'a> {
     s: &'a str,


### PR DESCRIPTION
This PR proposes a shorthand for defining and calling macros when using them as a reusable substitute for variables assigned complex values (e.g. string literals with or without newline escapes). The use-case is formatting - from my experience it's easier to visually parse a `macro`-`endmacro` block than a multiline variable assignment.

I might be alone in that regard, though - opinions?