### PR TITLE
Feature: Block fragments

### DIFF
--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -16,6 +16,7 @@ pub(crate) struct TemplateInput<'a> {
     pub(crate) config: &'a Config<'a>,
     pub(crate) syntax: &'a Syntax<'a>,
     pub(crate) source: &'a Source,
+    pub(crate) block: Option<&'a str>,
     pub(crate) print: Print,
     pub(crate) escaper: &'a str,
     pub(crate) ext: Option<&'a str>,
@@ -34,6 +35,7 @@ impl TemplateInput<'_> {
     ) -> Result<TemplateInput<'n>, CompileError> {
         let TemplateArgs {
             source,
+            block,
             print,
             escaping,
             ext,
@@ -95,6 +97,7 @@ impl TemplateInput<'_> {
             config,
             syntax,
             source,
+            block: block.as_deref(),
             print: *print,
             escaper,
             ext: ext.as_deref(),
@@ -210,6 +213,7 @@ impl TemplateInput<'_> {
 #[derive(Debug, Default)]
 pub(crate) struct TemplateArgs {
     source: Option<Source>,
+    block: Option<String>,
     print: Print,
     escaping: Option<String>,
     ext: Option<String>,
@@ -287,6 +291,12 @@ impl TemplateArgs {
                     args.source = Some(Source::Source(s.value()));
                 } else {
                     return Err("template source must be string literal".into());
+                }
+            } else if ident == "block" {
+                if let syn::Lit::Str(s) = value.lit {
+                    args.block = Some(s.value());
+                } else {
+                    return Err("block value must be string literal".into());
                 }
             } else if ident == "print" {
                 if let syn::Lit::Str(s) = value.lit {

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -66,7 +66,15 @@ pub(crate) fn build_template(ast: &syn::DeriveInput) -> Result<String, CompileEr
 
     let ctx = &contexts[&input.path];
     let heritage = if !ctx.blocks.is_empty() || ctx.extends.is_some() {
-        Some(Heritage::new(ctx, &contexts))
+        let heritage = Heritage::new(ctx, &contexts);
+
+        if let Some(block_name) = input.block {
+            if !heritage.blocks.contains_key(&block_name) {
+                return Err(format!("cannot find block {}", block_name).into());
+            }
+        }
+
+        Some(heritage)
     } else {
         None
     };

--- a/book/src/creating_templates.md
+++ b/book/src/creating_templates.md
@@ -75,6 +75,16 @@ recognized:
   #[template(path = "hello.html", print = "all")]
   struct HelloTemplate<'a> { ... }
   ```
+* `block` (as `block = "block_name"`): renders the block by itself.
+  Expressions outside of the block are not required by the struct, and
+  inheritance is also supported. This can be useful when you need to
+  decompose your template for partial rendering, without needing to
+  extract the partial into a separate template or macro.
+  ```rust
+  #[derive(Template)]
+  #[template(path = "hello.html", block = "hello")]
+  struct HelloTemplate<'a> { ... }
+  ```
 * `escape` (as `escape = "none"`): override the template's extension used for
   the purpose of determining the escaper for this template. See the section
   on configuring custom escapers for more information.

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -362,6 +362,21 @@ tag doesn't support whitespace control:
 The above code is rejected because we used `-` and `+`. For more information
 about whitespace control, take a look [here](#whitespace-control).
 
+### Block fragments
+
+Additionally, a block can be rendered by itself. This can be useful when
+you need to decompose your template for partial rendering, without
+needing to extract the partial into a separate template or macro. This
+can be done with the `block` parameter.
+
+```rust
+#[derive(Template)]
+#[template(path = "...", block = "my_block")]
+struct BlockFragment {
+    name: String,
+}
+```
+
 ## HTML escaping
 
 Askama by default escapes variables if it thinks it is rendering HTML

--- a/testing/templates/fragment-base.html
+++ b/testing/templates/fragment-base.html
@@ -1,0 +1,9 @@
+<html>
+<head></head>
+<body>
+{% block body %}
+<p>Parent body content</p>
+{% endblock %}
+{% block other_body %}{% endblock %}
+</body>
+</html>

--- a/testing/templates/fragment-mid-super.html
+++ b/testing/templates/fragment-mid-super.html
@@ -1,0 +1,9 @@
+{% extends "fragment-base.html" %}
+
+{% block body %}
+[{% call super() %}]
+{% endblock %}
+
+{% block other_body %}
+({% call super() %})
+{% endblock %}

--- a/testing/templates/fragment-nested-block.html
+++ b/testing/templates/fragment-nested-block.html
@@ -1,0 +1,13 @@
+{% extends "fragment-base.html" %}
+
+{% block body %}
+<p>Don't render me!</p>
+{% block nested %}
+<p>I should be here.</p>
+{% endblock %}
+{% endblock %}
+
+{% block other_body %}
+<p>Don't render me!</p>
+{% endblock %}
+

--- a/testing/templates/fragment-nested-super.html
+++ b/testing/templates/fragment-nested-super.html
@@ -1,0 +1,12 @@
+{% extends "fragment-mid-super.html" %}
+
+{% block body %}
+<p>Hello {{ name }}!</p>
+{% call super() %}
+{% endblock %}
+
+{% block other_body %}
+<p>Don't render me.</p>
+{% call super() %}
+{% endblock %}
+

--- a/testing/templates/fragment-simple.html
+++ b/testing/templates/fragment-simple.html
@@ -1,0 +1,9 @@
+{% extends "fragment-base.html" %}
+
+{% block body %}
+<p>Hello {{ name }}!</p>
+{% endblock %}
+
+{% block other_body %}
+<p>Don't render me.</p>
+{% endblock %}

--- a/testing/templates/fragment-super.html
+++ b/testing/templates/fragment-super.html
@@ -1,0 +1,12 @@
+{% extends "fragment-base.html" %}
+
+{% block body %}
+<p>Hello {{ name }}!</p>
+{% call super() %}
+{% endblock %}
+
+{% block other_body %}
+<p>Don't render me.</p>
+{% call super() %}
+{% endblock %}
+

--- a/testing/templates/fragment-unused-expr.html
+++ b/testing/templates/fragment-unused-expr.html
@@ -1,0 +1,12 @@
+{% extends "fragment-base.html" %}
+
+{{ not_required }}
+
+{% block body %}
+<p>{{ required }}</p>
+{% endblock %}
+
+{% block other_body %}
+{{ not_required_2 }}
+<p>Don't render me.</p>
+{% endblock %}

--- a/testing/tests/block_fragments.rs
+++ b/testing/tests/block_fragments.rs
@@ -1,0 +1,83 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(path = "fragment-simple.html", block = "body")]
+struct FragmentSimple<'a> {
+    name: &'a str,
+}
+
+/// Tests a simple base-inherited template with block fragment rendering.
+#[test]
+fn test_fragment_simple() {
+    let simple = FragmentSimple { name: "world" };
+
+    assert_eq!(simple.render().unwrap(), "\n\n<p>Hello world!</p>\n");
+}
+
+#[derive(Template)]
+#[template(path = "fragment-super.html", block = "body")]
+struct FragmentSuper<'a> {
+    name: &'a str,
+}
+
+/// Tests a case where a block fragment rendering calls the parent.
+/// Single inheritance only.
+#[test]
+fn test_fragment_super() {
+    let sup = FragmentSuper { name: "world" };
+
+    assert_eq!(
+        sup.render().unwrap(),
+        "\n\n<p>Hello world!</p>\n\n<p>Parent body content</p>\n\n"
+    );
+}
+
+#[derive(Template)]
+#[template(path = "fragment-nested-block.html", block = "nested")]
+struct FragmentNestedBlock;
+
+/// Tests rendering a block fragment inside of a block.
+#[test]
+fn test_fragment_nested_block() {
+    let nested_block = FragmentNestedBlock {};
+
+    assert_eq!(
+        nested_block.render().unwrap(),
+        "\n\n<p>I should be here.</p>\n"
+    );
+}
+
+#[derive(Template)]
+#[template(path = "fragment-nested-super.html", block = "body")]
+struct FragmentNestedSuper<'a> {
+    name: &'a str,
+}
+
+/// Tests rendering a block fragment with multiple inheritance.
+/// The middle parent adds square brackets around the base.
+#[test]
+fn test_fragment_nested_super() {
+    let nested_sup = FragmentNestedSuper { name: "world" };
+
+    assert_eq!(
+        nested_sup.render().unwrap(),
+        "\n\n<p>Hello world!</p>\n\n[\n<p>Parent body content</p>\n]\n\n"
+    );
+}
+
+#[derive(Template)]
+#[template(path = "fragment-unused-expr.html", block = "body")]
+struct FragmentUnusedExpr<'a> {
+    required: &'a str,
+}
+
+/// Tests a case where an expression is defined outside of a block fragment
+/// Ideally, the struct isn't required to define that field.
+#[test]
+fn test_fragment_unused_expression() {
+    let unused_expr = FragmentUnusedExpr {
+        required: "Required",
+    };
+
+    assert_eq!(unused_expr.render().unwrap(), "\n\n<p>Required</p>\n");
+}


### PR DESCRIPTION
Since https://github.com/djc/askama/pull/568 hasn't had an update in a long time, and it is a nice feature, this is a new PR to implement the proposed changes from that discussion.

This adds block fragments/partials as part of the Template derive. Here's an example of how to use it:

```rust
#[derive(Template)]
#[template(path = "...", block = "my_block")]
struct MyBlockFragment<'a> {
    name: &'a str,
}
```

This also properly supports inheritance, nesting, and the `super()` macro. It does this by abstracting `buf_writable` in the generator to add the ability to discard output, except for the block that needs to be rendered.