### PR TITLE
Added example on how to use super() in the docs

### DIFF
--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -141,7 +141,7 @@ A base template defines **blocks** that child templates can override.
   </head>
   <body>
     <div id="content">
-      {% block content %}{% endblock %}
+      {% block content %}<p>Placeholder content</p>{% endblock %}
     </div>
   </body>
 </html>
@@ -171,6 +171,7 @@ Here's an example child template:
 {% block content %}
   <h1>Index</h1>
   <p>Hello, world!</p>
+  {% call super() %}
 {% endblock %}
 ```
 


### PR DESCRIPTION
Resolves #825 

The default jinja syntax for `super()` doesn't require `call` and someone looking through the docs quickly might not realize that its the only way to call it, as macros are a slightly more advanced topic, more likely to be skipped over. 