### PR TITLE
Template node structs & whitespace semantics

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -642,7 +642,8 @@ impl<'a> Generator<'a> {
                     self.visit_lit(lit);
                 }
                 Node::Comment(ws) => {
-                    self.write_comment(ws);
+                    self.flush_ws(ws);
+                    self.prepare_ws(ws);
                 }
                 Node::Expr(ws, ref val) => {
                     self.write_expr(ws, val);
@@ -1311,10 +1312,6 @@ impl<'a> Generator<'a> {
         if !rws.is_empty() {
             self.next_ws = Some(rws);
         }
-    }
-
-    fn write_comment(&mut self, ws: Ws) {
-        self.handle_ws(ws);
     }
 
     /* Visitor methods for expression types */

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -684,7 +684,7 @@ impl<'a> Generator<'a> {
                 ) => {
                     size_hint += self.write_call(ctx, buf, ws, scope, name, args)?;
                 }
-                Node::Macro(_, ref m) => {
+                Node::Macro(ref m) => {
                     if level != AstLevel::Top {
                         return Err("macro blocks only allowed at the top level".into());
                     }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -656,7 +656,9 @@ impl<'a> Generator<'a> {
                     self.prepare_ws(ws);
                 }
                 Node::Let(ws, ref var, ref val) => {
-                    self.write_let(buf, ws, var, val)?;
+                    self.flush_ws(ws);
+                    self.write_let(buf, var, val)?;
+                    self.prepare_ws(ws);
                 }
                 Node::Cond(ws, ref conds) => {
                     self.flush_ws(ws);
@@ -1108,11 +1110,9 @@ impl<'a> Generator<'a> {
     fn write_let(
         &mut self,
         buf: &mut Buffer,
-        ws: Ws,
         var: &'a Target<'_>,
         val: &Expr<'_>,
     ) -> Result<(), CompileError> {
-        self.handle_ws(ws);
         let mut expr_buf = Buffer::new(0);
         self.visit_expr(&mut expr_buf, val)?;
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -665,9 +665,9 @@ impl<'a> Generator<'a> {
                     size_hint += self.write_cond(ctx, buf, conds)?;
                     self.prepare_ws(ws);
                 }
-                Node::Match(ws, Match { ref expr, ref arms }) => {
+                Node::Match(ws, ref match_node) => {
                     self.flush_ws(ws);
-                    size_hint += self.write_match(ctx, buf, expr, arms)?;
+                    size_hint += self.write_match(ctx, buf, match_node)?;
                     self.prepare_ws(ws);
                 }
                 Node::Loop(ws, ref loop_block) => {
@@ -815,9 +815,10 @@ impl<'a> Generator<'a> {
         &mut self,
         ctx: &'a Context<'_>,
         buf: &mut Buffer,
-        expr: &Expr<'_>,
-        arms: &'a [When<'_>],
+        match_node: &'a Match<'_>,
     ) -> Result<usize, CompileError> {
+        let Match { expr, arms } = match_node;
+
         let flushed = self.write_buf_writable(buf)?;
         let mut arm_sizes = Vec::new();
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -646,7 +646,9 @@ impl<'a> Generator<'a> {
                     self.prepare_ws(ws);
                 }
                 Node::Expr(ws, ref val) => {
-                    self.write_expr(ws, val);
+                    self.flush_ws(ws);
+                    self.write_expr(val);
+                    self.prepare_ws(ws);
                 }
                 Node::LetDecl(ws, ref var) => {
                     self.write_let_decl(buf, ws, var)?;
@@ -1195,8 +1197,7 @@ impl<'a> Generator<'a> {
         Ok(size_hint)
     }
 
-    fn write_expr(&mut self, ws: Ws, s: &'a Expr<'a>) {
-        self.handle_ws(ws);
+    fn write_expr(&mut self, s: &'a Expr<'a>) {
         self.buf_writable.push(Writable::Expr(s));
     }
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -656,15 +656,10 @@ impl<'a> Generator<'a> {
                 Node::Cond(ref conds, ws) => {
                     size_hint += self.write_cond(ctx, buf, conds, ws)?;
                 }
-                Node::Match(
-                    ws1,
-                    Match {
-                        ref expr,
-                        ref arms,
-                        ws,
-                    },
-                ) => {
-                    size_hint += self.write_match(ctx, buf, ws1, expr, arms, ws)?;
+                Node::Match(ws, Match { ref expr, ref arms }) => {
+                    self.flush_ws(ws);
+                    size_hint += self.write_match(ctx, buf, expr, arms)?;
+                    self.prepare_ws(ws);
                 }
                 Node::Loop(ws, ref loop_block) => {
                     self.flush_ws(ws);
@@ -809,12 +804,9 @@ impl<'a> Generator<'a> {
         &mut self,
         ctx: &'a Context<'_>,
         buf: &mut Buffer,
-        ws1: Ws,
         expr: &Expr<'_>,
         arms: &'a [When<'_>],
-        ws2: Ws,
     ) -> Result<usize, CompileError> {
-        self.flush_ws(ws1);
         let flushed = self.write_buf_writable(buf)?;
         let mut arm_sizes = Vec::new();
 
@@ -824,7 +816,6 @@ impl<'a> Generator<'a> {
         let mut arm_size = 0;
         for (i, arm) in arms.iter().enumerate() {
             let When { ws, target, block } = arm;
-            self.handle_ws(*ws);
 
             if i > 0 {
                 arm_sizes.push(arm_size + self.write_buf_writable(buf)?);
@@ -837,10 +828,11 @@ impl<'a> Generator<'a> {
             self.visit_target(buf, true, true, target);
             buf.writeln(" => {")?;
 
+            self.prepare_ws(*ws);
             arm_size = self.handle(ctx, block, buf, AstLevel::Nested)?;
+            self.flush_ws(*ws);
         }
 
-        self.handle_ws(ws2);
         arm_sizes.push(arm_size + self.write_buf_writable(buf)?);
         buf.writeln("}")?;
         self.locals.pop();

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -2,7 +2,7 @@ use crate::config::{get_template_source, read_config_file, Config, WhitespaceHan
 use crate::heritage::{Context, Heritage};
 use crate::input::{Print, Source, TemplateInput};
 use crate::parser::{
-    parse, Call, Cond, CondTest, Expr, Loop, Match, Node, Target, When, Whitespace, Ws,
+    parse, Call, Cond, CondTest, Expr, Lit, Loop, Match, Node, Target, When, Whitespace, Ws,
 };
 use crate::CompileError;
 
@@ -637,8 +637,8 @@ impl<'a> Generator<'a> {
         let mut size_hint = 0;
         for n in nodes {
             match *n {
-                Node::Lit(lws, val, rws) => {
-                    self.visit_lit(lws, val, rws);
+                Node::Lit(ref lit) => {
+                    self.visit_lit(lit);
                 }
                 Node::Comment(ws) => {
                     self.write_comment(ws);
@@ -691,9 +691,9 @@ impl<'a> Generator<'a> {
                     self.flush_ws(m.ws1);
                     self.prepare_ws(m.ws2);
                 }
-                Node::Raw(ws1, lws, val, rws, ws2) => {
+                Node::Raw(ws1, ref lit, ws2) => {
                     self.handle_ws(ws1);
-                    self.visit_lit(lws, val, rws);
+                    self.visit_lit(lit);
                     self.handle_ws(ws2);
                 }
                 Node::Import(ws, _, _) => {
@@ -1285,7 +1285,7 @@ impl<'a> Generator<'a> {
         Ok(size_hint)
     }
 
-    fn visit_lit(&mut self, lws: &'a str, val: &'a str, rws: &'a str) {
+    fn visit_lit(&mut self, Lit { lws, val, rws }: &'a Lit<'_>) {
         assert!(self.next_ws.is_none());
         if !lws.is_empty() {
             match self.skip_ws {

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -684,12 +684,11 @@ impl<'a> Generator<'a> {
                 ) => {
                     size_hint += self.write_call(ctx, buf, ws, scope, name, args)?;
                 }
-                Node::Macro(ref m) => {
+                Node::Macro(ws, _) => {
                     if level != AstLevel::Top {
                         return Err("macro blocks only allowed at the top level".into());
                     }
-                    self.flush_ws(m.ws1);
-                    self.prepare_ws(m.ws2);
+                    self.handle_ws(ws);
                 }
                 Node::Raw(ws1, ref lit, ws2) => {
                     self.handle_ws(ws1);
@@ -958,7 +957,7 @@ impl<'a> Generator<'a> {
         self.locals.push();
         self.write_buf_writable(buf)?;
         buf.writeln("{")?;
-        self.prepare_ws(def.ws1);
+        self.prepare_ws(def.ws);
 
         let mut names = Buffer::new(0);
         let mut values = Buffer::new(0);
@@ -1011,7 +1010,7 @@ impl<'a> Generator<'a> {
 
         let mut size_hint = self.handle(own_ctx, &def.nodes, buf, AstLevel::Nested)?;
 
-        self.flush_ws(def.ws2);
+        self.flush_ws(def.ws);
         size_hint += self.write_buf_writable(buf)?;
         buf.writeln("}")?;
         self.locals.pop();

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -821,8 +821,8 @@ impl<'a> Generator<'a> {
 
         let mut arm_size = 0;
         for (i, arm) in arms.iter().enumerate() {
-            let &(ws, ref target, ref body) = arm;
-            self.handle_ws(ws);
+            let When { ws, target, block } = arm;
+            self.handle_ws(*ws);
 
             if i > 0 {
                 arm_sizes.push(arm_size + self.write_buf_writable(buf)?);
@@ -835,7 +835,7 @@ impl<'a> Generator<'a> {
             self.visit_target(buf, true, true, target);
             buf.writeln(" => {")?;
 
-            arm_size = self.handle(ctx, body, buf, AstLevel::Nested)?;
+            arm_size = self.handle(ctx, block, buf, AstLevel::Nested)?;
         }
 
         self.handle_ws(ws2);

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -1,7 +1,9 @@
 use crate::config::{get_template_source, read_config_file, Config, WhitespaceHandling};
 use crate::heritage::{Context, Heritage};
 use crate::input::{Print, Source, TemplateInput};
-use crate::parser::{parse, Call, Cond, CondTest, Expr, Loop, Node, Target, When, Whitespace, Ws};
+use crate::parser::{
+    parse, Call, Cond, CondTest, Expr, Loop, Match, Node, Target, When, Whitespace, Ws,
+};
 use crate::CompileError;
 
 use proc_macro::TokenStream;
@@ -653,8 +655,15 @@ impl<'a> Generator<'a> {
                 Node::Cond(ref conds, ws) => {
                     size_hint += self.write_cond(ctx, buf, conds, ws)?;
                 }
-                Node::Match(ws1, ref expr, ref arms, ws2) => {
-                    size_hint += self.write_match(ctx, buf, ws1, expr, arms, ws2)?;
+                Node::Match(
+                    ws1,
+                    Match {
+                        ref expr,
+                        ref arms,
+                        ws,
+                    },
+                ) => {
+                    size_hint += self.write_match(ctx, buf, ws1, expr, arms, ws)?;
                 }
                 Node::Loop(ref loop_block) => {
                     size_hint += self.write_loop(ctx, buf, loop_block)?;

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -743,8 +743,8 @@ impl<'a> Generator<'a> {
         let mut flushed = 0;
         let mut arm_sizes = Vec::new();
         let mut has_else = false;
-        for (i, &(cws, ref cond, ref nodes)) in conds.iter().enumerate() {
-            self.handle_ws(cws);
+        for (i, cond) in conds.iter().enumerate() {
+            self.handle_ws(cond.ws);
             flushed += self.write_buf_writable(buf)?;
             if i > 0 {
                 self.locals.pop();
@@ -752,7 +752,7 @@ impl<'a> Generator<'a> {
 
             self.locals.push();
             let mut arm_size = 0;
-            if let Some(CondTest { target, expr }) = cond {
+            if let Some(CondTest { target, expr }) = &cond.test {
                 if i == 0 {
                     buf.write("if ");
                 } else {
@@ -787,7 +787,7 @@ impl<'a> Generator<'a> {
 
             buf.writeln(" {")?;
 
-            arm_size += self.handle(ctx, nodes, buf, AstLevel::Nested)?;
+            arm_size += self.handle(ctx, &cond.block, buf, AstLevel::Nested)?;
             arm_sizes.push(arm_size);
         }
         self.handle_ws(ws);

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -676,10 +676,14 @@ impl<'a> Generator<'a> {
                     self.prepare_ws(ws);
                 }
                 Node::BlockDef(ws, BlockDef { name, .. }) => {
-                    size_hint += self.write_block(buf, Some(name), ws)?;
+                    self.flush_ws(ws);
+                    size_hint += self.write_block(buf, Some(name))?;
+                    self.prepare_ws(ws);
                 }
                 Node::Include(ws, path) => {
-                    size_hint += self.handle_include(ctx, buf, ws, path)?;
+                    self.flush_ws(ws);
+                    size_hint += self.handle_include(ctx, buf, path)?;
+                    self.prepare_ws(ws);
                 }
                 Node::Call(
                     ws,
@@ -689,7 +693,9 @@ impl<'a> Generator<'a> {
                         ref args,
                     },
                 ) => {
-                    size_hint += self.write_call(ctx, buf, ws, scope, name, args)?;
+                    self.flush_ws(ws);
+                    size_hint += self.write_call(ctx, buf, scope, name, args)?;
+                    self.prepare_ws(ws);
                 }
                 Node::Macro(ws, _) => {
                     if level != AstLevel::Top {
@@ -925,13 +931,12 @@ impl<'a> Generator<'a> {
         &mut self,
         ctx: &'a Context<'_>,
         buf: &mut Buffer,
-        ws: Ws,
         scope: Option<&str>,
         name: &str,
         args: &[Expr<'_>],
     ) -> Result<usize, CompileError> {
         if name == "super" {
-            return self.write_block(buf, None, ws);
+            return self.write_block(buf, None);
         }
 
         let (def, own_ctx) = match scope {
@@ -957,7 +962,6 @@ impl<'a> Generator<'a> {
             }
         };
 
-        self.flush_ws(ws); // Cannot handle_ws() here: whitespace from macro definition comes first
         self.locals.push();
         self.write_buf_writable(buf)?;
         buf.writeln("{")?;
@@ -1018,7 +1022,6 @@ impl<'a> Generator<'a> {
         size_hint += self.write_buf_writable(buf)?;
         buf.writeln("}")?;
         self.locals.pop();
-        self.prepare_ws(ws);
         Ok(size_hint)
     }
 
@@ -1026,10 +1029,8 @@ impl<'a> Generator<'a> {
         &mut self,
         ctx: &'a Context<'_>,
         buf: &mut Buffer,
-        ws: Ws,
         path: &str,
     ) -> Result<usize, CompileError> {
-        self.flush_ws(ws);
         self.write_buf_writable(buf)?;
         let path = self
             .input
@@ -1057,7 +1058,6 @@ impl<'a> Generator<'a> {
             size_hint += gen.write_buf_writable(buf)?;
             size_hint
         };
-        self.prepare_ws(ws);
         Ok(size_hint)
     }
 
@@ -1140,11 +1140,7 @@ impl<'a> Generator<'a> {
         &mut self,
         buf: &mut Buffer,
         name: Option<&'a str>,
-        outer: Ws,
     ) -> Result<usize, CompileError> {
-        // Flush preceding whitespace according to the outer WS spec
-        self.flush_ws(outer);
-
         let prev_block = self.super_block;
         let cur = match (name, prev_block) {
             // The top-level context contains a block definition
@@ -1190,10 +1186,8 @@ impl<'a> Generator<'a> {
         self.locals.pop();
         self.flush_ws(*ws);
 
-        // Restore original block context and set whitespace suppression for
-        // succeeding whitespace according to the outer WS spec
+        // Restore original block context
         self.super_block = prev_block;
-        self.prepare_ws(outer);
         Ok(size_hint)
     }
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -2,7 +2,7 @@ use crate::config::{get_template_source, read_config_file, Config, WhitespaceHan
 use crate::heritage::{Context, Heritage};
 use crate::input::{Print, Source, TemplateInput};
 use crate::parser::{
-    parse, Call, Cond, CondTest, Expr, Lit, Loop, Match, Node, Target, When, Whitespace, Ws,
+    parse, Call, Cond, CondTest, Expr, Lit, Loop, Match, Node, Raw, Target, When, Whitespace, Ws,
 };
 use crate::CompileError;
 
@@ -690,10 +690,10 @@ impl<'a> Generator<'a> {
                     }
                     self.handle_ws(ws);
                 }
-                Node::Raw(ws1, ref lit, ws2) => {
-                    self.handle_ws(ws1);
-                    self.visit_lit(lit);
-                    self.handle_ws(ws2);
+                Node::Raw(ws, ref raw) => {
+                    self.flush_ws(ws);
+                    self.visit_raw(raw);
+                    self.prepare_ws(ws);
                 }
                 Node::Import(ws, _, _) => {
                     if level != AstLevel::Top {
@@ -1282,6 +1282,12 @@ impl<'a> Generator<'a> {
         buf.dedent()?;
         buf.writeln(")?;")?;
         Ok(size_hint)
+    }
+
+    fn visit_raw(&mut self, Raw { lit, ws }: &'a Raw<'_>) {
+        self.prepare_ws(*ws);
+        self.visit_lit(lit);
+        self.flush_ws(*ws);
     }
 
     fn visit_lit(&mut self, Lit { lws, val, rws }: &'a Lit<'_>) {

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -651,7 +651,9 @@ impl<'a> Generator<'a> {
                     self.prepare_ws(ws);
                 }
                 Node::LetDecl(ws, ref var) => {
-                    self.write_let_decl(buf, ws, var)?;
+                    self.flush_ws(ws);
+                    self.write_let_decl(buf, var)?;
+                    self.prepare_ws(ws);
                 }
                 Node::Let(ws, ref var, ref val) => {
                     self.write_let(buf, ws, var, val)?;
@@ -1060,10 +1062,8 @@ impl<'a> Generator<'a> {
     fn write_let_decl(
         &mut self,
         buf: &mut Buffer,
-        ws: Ws,
         var: &'a Target<'_>,
     ) -> Result<(), CompileError> {
-        self.handle_ws(ws);
         self.write_buf_writable(buf)?;
         buf.write("let ");
         self.visit_target(buf, false, true, var);

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -1,7 +1,7 @@
 use crate::config::{get_template_source, read_config_file, Config, WhitespaceHandling};
 use crate::heritage::{Context, Heritage};
 use crate::input::{Print, Source, TemplateInput};
-use crate::parser::{parse, Cond, CondTest, Expr, Loop, Node, Target, When, Whitespace, Ws};
+use crate::parser::{parse, Call, Cond, CondTest, Expr, Loop, Node, Target, When, Whitespace, Ws};
 use crate::CompileError;
 
 use proc_macro::TokenStream;
@@ -665,7 +665,14 @@ impl<'a> Generator<'a> {
                 Node::Include(ws, path) => {
                     size_hint += self.handle_include(ctx, buf, ws, path)?;
                 }
-                Node::Call(ws, scope, name, ref args) => {
+                Node::Call(
+                    ws,
+                    Call {
+                        scope,
+                        name,
+                        ref args,
+                    },
+                ) => {
                     size_hint += self.write_call(ctx, buf, ws, scope, name, args)?;
                 }
                 Node::Macro(_, ref m) => {

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -701,7 +701,8 @@ impl<'a> Generator<'a> {
                     if level != AstLevel::Top {
                         return Err("macro blocks only allowed at the top level".into());
                     }
-                    self.handle_ws(ws);
+                    self.flush_ws(ws);
+                    self.prepare_ws(ws);
                 }
                 Node::Raw(ws, ref raw) => {
                     self.flush_ws(ws);
@@ -712,7 +713,8 @@ impl<'a> Generator<'a> {
                     if level != AstLevel::Top {
                         return Err("import blocks only allowed at the top level".into());
                     }
-                    self.handle_ws(ws);
+                    self.flush_ws(ws);
+                    self.prepare_ws(ws);
                 }
                 Node::Extends(_) => {
                     if level != AstLevel::Top {
@@ -722,12 +724,14 @@ impl<'a> Generator<'a> {
                     // except for the blocks defined in it.
                 }
                 Node::Break(ws) => {
-                    self.handle_ws(ws);
+                    self.flush_ws(ws);
+                    self.prepare_ws(ws);
                     self.write_buf_writable(buf)?;
                     buf.writeln("break;")?;
                 }
                 Node::Continue(ws) => {
-                    self.handle_ws(ws);
+                    self.flush_ws(ws);
+                    self.prepare_ws(ws);
                     self.write_buf_writable(buf)?;
                     buf.writeln("continue;")?;
                 }
@@ -1869,13 +1873,6 @@ impl<'a> Generator<'a> {
     }
 
     /* Helper methods for dealing with whitespace nodes */
-
-    // Combines `flush_ws()` and `prepare_ws()` to handle both trailing whitespace from the
-    // preceding literal and leading whitespace from the succeeding literal.
-    fn handle_ws(&mut self, ws: Ws) {
-        self.flush_ws(ws);
-        self.prepare_ws(ws);
-    }
 
     fn should_trim_ws(&self, ws: Option<Whitespace>) -> WhitespaceHandling {
         match ws {

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::config::Config;
-use crate::parser::{Loop, Macro, Match, Node, When};
+use crate::parser::{Cond, Loop, Macro, Match, Node, When};
 use crate::CompileError;
 
 pub(crate) struct Heritage<'a> {
@@ -83,8 +83,8 @@ impl Context<'_> {
                         }
                     }
                     Node::Cond(branches, _) => {
-                        for (_, _, nodes) in branches {
-                            nested.push(nodes);
+                        for Cond { block, .. } in branches {
+                            nested.push(block);
                         }
                     }
                     Node::Loop(Loop {

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -64,14 +64,14 @@ impl Context<'_> {
                             extends = Some(config.find_template(extends_path, Some(path))?);
                         }
                     },
-                    Node::Macro(m) if top => {
+                    Node::Macro(_, m) if top => {
                         macros.insert(m.name, m);
                     }
                     Node::Import(_, import_path, scope) if top => {
                         let path = config.find_template(import_path, Some(path))?;
                         imports.insert(*scope, path);
                     }
-                    Node::Extends(_) | Node::Macro(_) | Node::Import(_, _, _) if !top => {
+                    Node::Extends(_) | Node::Macro(_, _) | Node::Import(_, _, _) if !top => {
                         return Err(
                             "extends, macro or import blocks not allowed below top level".into(),
                         );

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::config::Config;
-use crate::parser::{Loop, Macro, Node};
+use crate::parser::{Loop, Macro, Match, Node};
 use crate::CompileError;
 
 pub(crate) struct Heritage<'a> {
@@ -93,7 +93,7 @@ impl Context<'_> {
                         nested.push(body);
                         nested.push(else_block);
                     }
-                    Node::Match(_, _, arms, _) => {
+                    Node::Match(_, Match { arms, .. }) => {
                         for (_, _, arm) in arms {
                             nested.push(arm);
                         }

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -85,9 +85,12 @@ impl Context<'_> {
                             nested.push(block);
                         }
                     }
-                    Node::Loop(Loop {
-                        body, else_block, ..
-                    }) => {
+                    Node::Loop(
+                        _,
+                        Loop {
+                            body, else_block, ..
+                        },
+                    ) => {
                         nested.push(body);
                         nested.push(else_block);
                     }

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::config::Config;
-use crate::parser::{Loop, Macro, Match, Node};
+use crate::parser::{Loop, Macro, Match, Node, When};
 use crate::CompileError;
 
 pub(crate) struct Heritage<'a> {
@@ -94,8 +94,8 @@ impl Context<'_> {
                         nested.push(else_block);
                     }
                     Node::Match(_, Match { arms, .. }) => {
-                        for (_, _, arm) in arms {
-                            nested.push(arm);
+                        for When { block, .. } in arms {
+                            nested.push(block);
                         }
                     }
                     _ => {}

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -80,7 +80,7 @@ impl Context<'_> {
                         blocks.push(def);
                         nested.push(block);
                     }
-                    Node::Cond(branches, _) => {
+                    Node::Cond(_, branches) => {
                         for Cond { block, .. } in branches {
                             nested.push(block);
                         }

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -64,14 +64,14 @@ impl Context<'_> {
                             extends = Some(config.find_template(extends_path, Some(path))?);
                         }
                     },
-                    Node::Macro(name, m) if top => {
-                        macros.insert(*name, m);
+                    Node::Macro(m) if top => {
+                        macros.insert(m.name, m);
                     }
                     Node::Import(_, import_path, scope) if top => {
                         let path = config.find_template(import_path, Some(path))?;
                         imports.insert(*scope, path);
                     }
-                    Node::Extends(_) | Node::Macro(_, _) | Node::Import(_, _, _) if !top => {
+                    Node::Extends(_) | Node::Macro(_) | Node::Import(_, _, _) if !top => {
                         return Err(
                             "extends, macro or import blocks not allowed below top level".into(),
                         );

--- a/askama_derive/src/parser/mod.rs
+++ b/askama_derive/src/parser/mod.rs
@@ -12,7 +12,9 @@ use nom::sequence::{delimited, pair, tuple};
 use nom::{error_position, AsChar, IResult, InputTakeAtPosition};
 
 pub(crate) use self::expr::Expr;
-pub(crate) use self::node::{Cond, CondTest, Loop, Macro, Node, Target, When, Whitespace, Ws};
+pub(crate) use self::node::{
+    Call, Cond, CondTest, Loop, Macro, Node, Target, When, Whitespace, Ws,
+};
 use crate::config::Syntax;
 use crate::CompileError;
 

--- a/askama_derive/src/parser/mod.rs
+++ b/askama_derive/src/parser/mod.rs
@@ -13,7 +13,8 @@ use nom::{error_position, AsChar, IResult, InputTakeAtPosition};
 
 pub(crate) use self::expr::Expr;
 pub(crate) use self::node::{
-    Call, Cond, CondTest, Lit, Loop, Macro, Match, Node, Raw, Target, When, Whitespace, Ws,
+    BlockDef, Call, Cond, CondTest, Lit, Loop, Macro, Match, Node, Raw, Target, When, Whitespace,
+    Ws,
 };
 use crate::config::Syntax;
 use crate::CompileError;

--- a/askama_derive/src/parser/mod.rs
+++ b/askama_derive/src/parser/mod.rs
@@ -13,7 +13,7 @@ use nom::{error_position, AsChar, IResult, InputTakeAtPosition};
 
 pub(crate) use self::expr::Expr;
 pub(crate) use self::node::{
-    Call, Cond, CondTest, Loop, Macro, Node, Target, When, Whitespace, Ws,
+    Call, Cond, CondTest, Loop, Macro, Match, Node, Target, When, Whitespace, Ws,
 };
 use crate::config::Syntax;
 use crate::CompileError;

--- a/askama_derive/src/parser/mod.rs
+++ b/askama_derive/src/parser/mod.rs
@@ -13,7 +13,7 @@ use nom::{error_position, AsChar, IResult, InputTakeAtPosition};
 
 pub(crate) use self::expr::Expr;
 pub(crate) use self::node::{
-    Call, Cond, CondTest, Lit, Loop, Macro, Match, Node, Target, When, Whitespace, Ws,
+    Call, Cond, CondTest, Lit, Loop, Macro, Match, Node, Raw, Target, When, Whitespace, Ws,
 };
 use crate::config::Syntax;
 use crate::CompileError;

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -32,7 +32,7 @@ pub(crate) enum Node<'a> {
     Include(Ws, &'a str),
     Import(Ws, &'a str, &'a str),
     Macro(Ws, Macro<'a>),
-    Raw(Ws, Lit<'a>, Ws),
+    Raw(Ws, Raw<'a>),
     Break(Ws),
     Continue(Ws),
 }
@@ -72,6 +72,13 @@ pub(crate) struct Lit<'a> {
     pub(crate) lws: &'a str,
     pub(crate) val: &'a str,
     pub(crate) rws: &'a str,
+}
+
+/// A raw block to output directly.
+#[derive(Debug, PartialEq)]
+pub(crate) struct Raw<'a> {
+    pub(crate) lit: Lit<'a>,
+    pub(crate) ws: Ws,
 }
 
 /// A macro call statement.
@@ -544,9 +551,9 @@ fn block_raw<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
 
     let (_, (pws1, _, (nws1, _, (contents, (i, (_, pws2, _, nws2, _)))))) = p(i)?;
     let lit = split_ws_parts(contents);
-    let ws1 = Ws(pws1, nws1);
-    let ws2 = Ws(pws2, nws2);
-    Ok((i, Node::Raw(ws1, lit, ws2)))
+    let outer = Ws(pws1, nws2);
+    let ws = Ws(pws2, nws1);
+    Ok((i, Node::Raw(outer, Raw { lit, ws })))
 }
 
 fn break_statement<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -21,7 +21,7 @@ pub(crate) enum Node<'a> {
     Lit(&'a str, &'a str, &'a str),
     Comment(Ws),
     Expr(Ws, Expr<'a>),
-    Call(Ws, Option<&'a str>, &'a str, Vec<Expr<'a>>),
+    Call(Ws, Call<'a>),
     LetDecl(Ws, Target<'a>),
     Let(Ws, Target<'a>, Expr<'a>),
     Cond(Vec<Cond<'a>>, Ws),
@@ -64,6 +64,17 @@ impl From<WhitespaceHandling> for Whitespace {
             WhitespaceHandling::Minimize => Whitespace::Minimize,
         }
     }
+}
+
+/// A macro call statement.
+#[derive(Debug, PartialEq)]
+pub(crate) struct Call<'a> {
+    /// If the macro is imported, the scope name.
+    pub(crate) scope: Option<&'a str>,
+    /// The name of the macro to call.
+    pub(crate) name: &'a str,
+    /// The arguments to the macro.
+    pub(crate) args: Vec<Expr<'a>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -140,7 +151,7 @@ fn block_call(i: &str) -> IResult<&str, Node<'_>> {
     let (i, (pws, _, (scope, name, args, nws))) = p(i)?;
     let scope = scope.map(|(scope, _)| scope);
     let args = args.unwrap_or_default();
-    Ok((i, Node::Call(Ws(pws, nws), scope, name, args)))
+    Ok((i, Node::Call(Ws(pws, nws), Call { scope, name, args })))
 }
 
 fn cond_if(i: &str) -> IResult<&str, CondTest<'_>> {

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -26,7 +26,7 @@ pub(crate) enum Node<'a> {
     Let(Ws, Target<'a>, Expr<'a>),
     Cond(Vec<Cond<'a>>, Ws),
     Match(Ws, Match<'a>),
-    Loop(Loop<'a>),
+    Loop(Ws, Loop<'a>),
     Extends(&'a str),
     BlockDef(Ws, BlockDef<'a>),
     Include(Ws, &'a str),
@@ -114,14 +114,13 @@ pub(crate) struct When<'a> {
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Loop<'a> {
-    pub(crate) ws1: Ws,
     pub(crate) var: Target<'a>,
     pub(crate) iter: Expr<'a>,
     pub(crate) cond: Option<Expr<'a>>,
     pub(crate) body: Vec<Node<'a>>,
-    pub(crate) ws2: Ws,
+    pub(crate) body_ws: Ws,
     pub(crate) else_block: Vec<Node<'a>>,
-    pub(crate) ws3: Ws,
+    pub(crate) else_ws: Ws,
 }
 
 #[derive(Debug, PartialEq)]
@@ -427,16 +426,18 @@ fn block_for<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
     let (nws3, else_block, pws3) = else_block.unwrap_or_default();
     Ok((
         i,
-        Node::Loop(Loop {
-            ws1: Ws(pws1, nws1),
-            var,
-            iter,
-            cond,
-            body,
-            ws2: Ws(pws2, nws3),
-            else_block,
-            ws3: Ws(pws3, nws2),
-        }),
+        Node::Loop(
+            Ws(pws1, nws2),
+            Loop {
+                var,
+                iter,
+                cond,
+                body,
+                body_ws: Ws(pws2, nws1),
+                else_block,
+                else_ws: Ws(pws3, nws3),
+            },
+        ),
     ))
 }
 

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -25,7 +25,7 @@ pub(crate) enum Node<'a> {
     LetDecl(Ws, Target<'a>),
     Let(Ws, Target<'a>, Expr<'a>),
     Cond(Vec<Cond<'a>>, Ws),
-    Match(Ws, Expr<'a>, Vec<When<'a>>, Ws),
+    Match(Ws, Match<'a>),
     Loop(Loop<'a>),
     Extends(&'a str),
     BlockDef(Ws, &'a str, Vec<Node<'a>>, Ws),
@@ -75,6 +75,16 @@ pub(crate) struct Call<'a> {
     pub(crate) name: &'a str,
     /// The arguments to the macro.
     pub(crate) args: Vec<Expr<'a>>,
+}
+
+/// A match statement.
+#[derive(Debug, PartialEq)]
+pub(crate) struct Match<'a> {
+    /// The expression to match against.
+    pub(crate) expr: Expr<'a>,
+    /// Each of the match arms, with a pattern and a body.
+    pub(crate) arms: Vec<When<'a>>,
+    pub(crate) ws: Ws,
 }
 
 #[derive(Debug, PartialEq)]
@@ -267,13 +277,14 @@ fn block_match<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
         ))),
     ));
     let (i, (pws1, _, (expr, nws1, _, (_, arms, (else_arm, (_, pws2, _, nws2)))))) = p(i)?;
+    let ws = Ws(pws2, nws2);
 
     let mut arms = arms;
     if let Some(arm) = else_arm {
         arms.push(arm);
     }
 
-    Ok((i, Node::Match(Ws(pws1, nws1), expr, arms, Ws(pws2, nws2))))
+    Ok((i, Node::Match(Ws(pws1, nws1), Match { expr, arms, ws })))
 }
 
 fn block_let(i: &str) -> IResult<&str, Node<'_>> {

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -24,7 +24,7 @@ pub(crate) enum Node<'a> {
     Call(Ws, Call<'a>),
     LetDecl(Ws, Target<'a>),
     Let(Ws, Target<'a>, Expr<'a>),
-    Cond(Vec<Cond<'a>>, Ws),
+    Cond(Ws, Vec<Cond<'a>>),
     Match(Ws, Match<'a>),
     Loop(Ws, Loop<'a>),
     Extends(&'a str),
@@ -267,7 +267,21 @@ fn block_if<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
         block,
     }];
     res.extend(elifs);
-    Ok((i, Node::Cond(res, Ws(pws2, nws2))))
+
+    let outer = Ws(pws1, nws2);
+
+    let mut cursor = pws2;
+    let mut idx = res.len() - 1;
+    loop {
+        std::mem::swap(&mut cursor, &mut res[idx].ws.0);
+
+        if idx == 0 {
+            break;
+        }
+        idx -= 1;
+    }
+
+    Ok((i, Node::Cond(outer, res)))
 }
 
 fn match_else_block<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, When<'a>> {

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -31,7 +31,7 @@ pub(crate) enum Node<'a> {
     BlockDef(Ws, &'a str, Vec<Node<'a>>, Ws),
     Include(Ws, &'a str),
     Import(Ws, &'a str, &'a str),
-    Macro(Macro<'a>),
+    Macro(Ws, Macro<'a>),
     Raw(Ws, Lit<'a>, Ws),
     Break(Ws),
     Continue(Ws),
@@ -120,10 +120,9 @@ pub(crate) struct Loop<'a> {
 #[derive(Debug, PartialEq)]
 pub(crate) struct Macro<'a> {
     pub(crate) name: &'a str,
-    pub(crate) ws1: Ws,
     pub(crate) args: Vec<&'a str>,
     pub(crate) nodes: Vec<Node<'a>>,
-    pub(crate) ws2: Ws,
+    pub(crate) ws: Ws,
 }
 
 /// First field is "minus/plus sign was used on the left part of the item".
@@ -512,13 +511,15 @@ fn block_macro<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
 
     Ok((
         i,
-        Node::Macro(Macro {
-            name,
-            ws1: Ws(pws1, nws1),
-            args: params,
-            nodes: contents,
-            ws2: Ws(pws2, nws2),
-        }),
+        Node::Macro(
+            Ws(pws1, nws2),
+            Macro {
+                name,
+                args: params,
+                nodes: contents,
+                ws: Ws(pws2, nws1),
+            },
+        ),
     ))
 }
 

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -31,7 +31,7 @@ pub(crate) enum Node<'a> {
     BlockDef(Ws, &'a str, Vec<Node<'a>>, Ws),
     Include(Ws, &'a str),
     Import(Ws, &'a str, &'a str),
-    Macro(&'a str, Macro<'a>),
+    Macro(Macro<'a>),
     Raw(Ws, Lit<'a>, Ws),
     Break(Ws),
     Continue(Ws),
@@ -119,6 +119,7 @@ pub(crate) struct Loop<'a> {
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Macro<'a> {
+    pub(crate) name: &'a str,
     pub(crate) ws1: Ws,
     pub(crate) args: Vec<&'a str>,
     pub(crate) nodes: Vec<Node<'a>>,
@@ -511,15 +512,13 @@ fn block_macro<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {
 
     Ok((
         i,
-        Node::Macro(
+        Node::Macro(Macro {
             name,
-            Macro {
-                ws1: Ws(pws1, nws1),
-                args: params,
-                nodes: contents,
-                ws2: Ws(pws2, nws2),
-            },
-        ),
+            ws1: Ws(pws1, nws1),
+            args: params,
+            nodes: contents,
+            ws2: Ws(pws2, nws2),
+        }),
     ))
 }
 

--- a/askama_derive/src/parser/node.rs
+++ b/askama_derive/src/parser/node.rs
@@ -87,6 +87,16 @@ pub(crate) struct Match<'a> {
     pub(crate) ws: Ws,
 }
 
+/// A single arm of a match statement.
+#[derive(Debug, PartialEq)]
+pub(crate) struct When<'a> {
+    pub(crate) ws: Ws,
+    /// The target pattern to match.
+    pub(crate) target: Target<'a>,
+    /// Body of the match arm.
+    pub(crate) block: Vec<Node<'a>>,
+}
+
 #[derive(Debug, PartialEq)]
 pub(crate) struct Loop<'a> {
     pub(crate) ws1: Ws,
@@ -98,8 +108,6 @@ pub(crate) struct Loop<'a> {
     pub(crate) else_block: Vec<Node<'a>>,
     pub(crate) ws3: Ws,
 }
-
-pub(crate) type When<'a> = (Ws, Target<'a>, Vec<Node<'a>>);
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Macro<'a> {
@@ -234,7 +242,14 @@ fn match_else_block<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, When<'a>>
         ))),
     ));
     let (i, (_, pws, _, (nws, _, block))) = p(i)?;
-    Ok((i, (Ws(pws, nws), Target::Name("_"), block)))
+    Ok((
+        i,
+        When {
+            ws: Ws(pws, nws),
+            target: Target::Name("_"),
+            block,
+        },
+    ))
 }
 
 fn when_block<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, When<'a>> {
@@ -250,7 +265,14 @@ fn when_block<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, When<'a>> {
         ))),
     ));
     let (i, (_, pws, _, (target, nws, _, block))) = p(i)?;
-    Ok((i, (Ws(pws, nws), target, block)))
+    Ok((
+        i,
+        When {
+            ws: Ws(pws, nws),
+            target,
+            block,
+        },
+    ))
 }
 
 fn block_match<'a>(i: &'a str, s: &State<'_>) -> IResult<&'a str, Node<'a>> {

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -730,3 +730,17 @@ fn test_parse_raw_block() {
         )]
     );
 }
+
+#[test]
+fn test_parse_block_def() {
+    let syntax = Syntax::default();
+    assert_eq!(
+        super::parse("{% block foo -%}{%~ endblock +%}", &syntax).unwrap(),
+        vec![Node::BlockDef(
+            Ws(None, Some(Whitespace::Suppress)),
+            "foo",
+            vec![],
+            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+        )],
+    );
+}

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -548,17 +548,16 @@ fn test_parse_match() {
                 expr: Expr::Var("foo"),
                 arms: vec![
                     When {
-                        ws: Ws(None, Some(Whitespace::Minimize)),
+                        ws: Ws(Some(Whitespace::Suppress), Some(Whitespace::Minimize)),
                         target: Target::Path(vec!["Foo"]),
                         block: vec![],
                     },
                     When {
-                        ws: Ws(Some(Whitespace::Suppress), Some(Whitespace::Preserve)),
+                        ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
                         target: Target::Name("_"),
                         block: vec![],
                     }
                 ],
-                ws: Ws(Some(Whitespace::Minimize), None),
             }
         )],
     );

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -709,6 +709,7 @@ fn test_parse_macro_statement() {
 
 #[test]
 fn test_parse_raw_block() {
+    use super::Raw;
     let syntax = Syntax::default();
     assert_eq!(
         super::parse(
@@ -717,13 +718,15 @@ fn test_parse_raw_block() {
         )
         .unwrap(),
         vec![Node::Raw(
-            Ws(None, Some(Whitespace::Suppress)),
-            Lit {
-                lws: "",
-                val: "{% if condition %}{{ result }}{% endif %}",
-                rws: "",
-            },
-            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+            Ws(None, Some(Whitespace::Preserve)),
+            Raw {
+                lit: Lit {
+                    lws: "",
+                    val: "{% if condition %}{{ result }}{% endif %}",
+                    rws: "",
+                },
+                ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Suppress)),
+            }
         )]
     );
 }

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -669,25 +669,28 @@ fn test_missing_space_after_kw() {
 
 #[test]
 fn test_parse_call_statement() {
+    use super::Call;
     let syntax = Syntax::default();
     assert_eq!(
         super::parse("{% call foo(bar) %}", &syntax).unwrap(),
         vec![Node::Call(
             Ws(None, None),
-            None,
-            "foo",
-            vec![
-                Expr::Var("bar"),
-            ],
+            Call {
+                scope: None,
+                name: "foo",
+                args: vec![Expr::Var("bar"),],
+            }
         )],
     );
     assert_eq!(
         super::parse("{% call foo::bar() %}", &syntax).unwrap(),
         vec![Node::Call(
             Ws(None, None),
-            Some("foo"),
-            "bar",
-            vec![],
+            Call {
+                scope: Some("foo"),
+                name: "bar",
+                args: vec![],
+            }
         )],
     );
 }

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -657,29 +657,33 @@ fn test_parse_loop() {
     let syntax = Syntax::default();
     assert_eq!(
         super::parse("{% for user in users +%}{%~ else -%}{%+ endfor %}", &syntax).unwrap(),
-        vec![Node::Loop(Loop {
-            ws1: Ws(None, Some(Whitespace::Preserve)),
-            var: Target::Name("user"),
-            iter: Expr::Var("users"),
-            cond: None,
-            body: vec![],
-            ws2: Ws(Some(Whitespace::Minimize), Some(Whitespace::Suppress)),
-            else_block: vec![],
-            ws3: Ws(Some(Whitespace::Preserve), None),
-        })]
+        vec![Node::Loop(
+            Ws(None, None),
+            Loop {
+                var: Target::Name("user"),
+                iter: Expr::Var("users"),
+                cond: None,
+                body: vec![],
+                body_ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+                else_block: vec![],
+                else_ws: Ws(Some(Whitespace::Preserve), Some(Whitespace::Suppress)),
+            },
+        )]
     );
     assert_eq!(
         super::parse("{% for user in users +%}{%~ endfor -%}", &syntax).unwrap(),
-        vec![Node::Loop(Loop {
-            ws1: Ws(None, Some(Whitespace::Preserve)),
-            var: Target::Name("user"),
-            iter: Expr::Var("users"),
-            cond: None,
-            body: vec![],
-            ws2: Ws(Some(Whitespace::Minimize), None),
-            else_block: vec![],
-            ws3: Ws(None, Some(Whitespace::Suppress)),
-        })]
+        vec![Node::Loop(
+            Ws(None, Some(Whitespace::Suppress)),
+            Loop {
+                var: Target::Name("user"),
+                iter: Expr::Var("users"),
+                cond: None,
+                body: vec![],
+                body_ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+                else_block: vec![],
+                else_ws: Ws(None, None),
+            },
+        )]
     );
 }
 

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -822,29 +822,29 @@ fn test_parse_cond() {
     assert_eq!(
         super::parse("{% if condition -%}{%~ endif +%}", &syntax).unwrap(),
         vec![Node::Cond(
+            Ws(None, Some(Whitespace::Preserve)),
             vec![Cond {
                 test: Some(CondTest {
                     expr: Expr::Var("condition"),
                     target: None,
                 }),
                 block: vec![],
-                ws: Ws(None, Some(Whitespace::Suppress)),
+                ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Suppress)),
             },],
-            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
         )],
     );
     assert_eq!(
         super::parse("{% if let Some(val) = condition -%}{%~ endif +%}", &syntax).unwrap(),
         vec![Node::Cond(
+            Ws(None, Some(Whitespace::Preserve)),
             vec![Cond {
                 test: Some(CondTest {
                     expr: Expr::Var("condition"),
                     target: Some(Target::Tuple(vec!["Some"], vec![Target::Name("val")],)),
                 }),
                 block: vec![],
-                ws: Ws(None, Some(Whitespace::Suppress)),
+                ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Suppress)),
             },],
-            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
         )],
     );
     assert_eq!(
@@ -854,6 +854,7 @@ fn test_parse_cond() {
         )
         .unwrap(),
         vec![Node::Cond(
+            Ws(None, Some(Whitespace::Preserve)),
             vec![
                 Cond {
                     test: Some(CondTest {
@@ -861,7 +862,7 @@ fn test_parse_cond() {
                         target: None,
                     }),
                     block: vec![],
-                    ws: Ws(None, Some(Whitespace::Suppress)),
+                    ws: Ws(Some(Whitespace::Preserve), Some(Whitespace::Suppress)),
                 },
                 Cond {
                     test: Some(CondTest {
@@ -869,7 +870,7 @@ fn test_parse_cond() {
                         target: None,
                     }),
                     block: vec![],
-                    ws: Ws(Some(Whitespace::Preserve), Some(Whitespace::Suppress)),
+                    ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Suppress)),
                 },
                 Cond {
                     test: None,
@@ -877,7 +878,6 @@ fn test_parse_cond() {
                     ws: Ws(Some(Whitespace::Minimize), None),
                 },
             ],
-            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
         )],
     );
 }

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -695,12 +695,14 @@ fn test_parse_macro_statement() {
     let syntax = Syntax::default();
     assert_eq!(
         super::parse("{% macro foo(bar) -%}{%~ endmacro +%}", &syntax).unwrap(),
-        vec![Node::Macro(Macro {
-            name: "foo",
-            ws1: Ws(None, Some(Whitespace::Suppress)),
-            args: vec!["bar"],
-            nodes: vec![],
-            ws2: Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
-        },)]
+        vec![Node::Macro(
+            Ws(None, Some(Whitespace::Preserve)),
+            Macro {
+                name: "foo",
+                args: vec!["bar"],
+                nodes: vec![],
+                ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Suppress)),
+            },
+        )]
     );
 }

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -706,3 +706,24 @@ fn test_parse_macro_statement() {
         )]
     );
 }
+
+#[test]
+fn test_parse_raw_block() {
+    let syntax = Syntax::default();
+    assert_eq!(
+        super::parse(
+            "{% raw -%}{% if condition %}{{ result }}{% endif %}{%~ endraw +%}",
+            &syntax
+        )
+        .unwrap(),
+        vec![Node::Raw(
+            Ws(None, Some(Whitespace::Suppress)),
+            Lit {
+                lws: "",
+                val: "{% if condition %}{{ result }}{% endif %}",
+                rws: "",
+            },
+            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+        )]
+    );
+}

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -666,3 +666,28 @@ fn test_missing_space_after_kw() {
         "unable to parse template:\n\n\"{%leta=b%}\""
     ));
 }
+
+#[test]
+fn test_parse_call_statement() {
+    let syntax = Syntax::default();
+    assert_eq!(
+        super::parse("{% call foo(bar) %}", &syntax).unwrap(),
+        vec![Node::Call(
+            Ws(None, None),
+            None,
+            "foo",
+            vec![
+                Expr::Var("bar"),
+            ],
+        )],
+    );
+    assert_eq!(
+        super::parse("{% call foo::bar() %}", &syntax).unwrap(),
+        vec![Node::Call(
+            Ws(None, None),
+            Some("foo"),
+            "bar",
+            vec![],
+        )],
+    );
+}

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -814,3 +814,70 @@ fn test_parse_block_def() {
         )],
     );
 }
+
+#[test]
+fn test_parse_cond() {
+    use super::{Cond, CondTest};
+    let syntax = Syntax::default();
+    assert_eq!(
+        super::parse("{% if condition -%}{%~ endif +%}", &syntax).unwrap(),
+        vec![Node::Cond(
+            vec![Cond {
+                test: Some(CondTest {
+                    expr: Expr::Var("condition"),
+                    target: None,
+                }),
+                block: vec![],
+                ws: Ws(None, Some(Whitespace::Suppress)),
+            },],
+            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+        )],
+    );
+    assert_eq!(
+        super::parse("{% if let Some(val) = condition -%}{%~ endif +%}", &syntax).unwrap(),
+        vec![Node::Cond(
+            vec![Cond {
+                test: Some(CondTest {
+                    expr: Expr::Var("condition"),
+                    target: Some(Target::Tuple(vec!["Some"], vec![Target::Name("val")],)),
+                }),
+                block: vec![],
+                ws: Ws(None, Some(Whitespace::Suppress)),
+            },],
+            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+        )],
+    );
+    assert_eq!(
+        super::parse(
+            "{% if condition -%}{%+ else if other -%}{%~ else %}{%~ endif +%}",
+            &syntax
+        )
+        .unwrap(),
+        vec![Node::Cond(
+            vec![
+                Cond {
+                    test: Some(CondTest {
+                        expr: Expr::Var("condition"),
+                        target: None,
+                    }),
+                    block: vec![],
+                    ws: Ws(None, Some(Whitespace::Suppress)),
+                },
+                Cond {
+                    test: Some(CondTest {
+                        expr: Expr::Var("other"),
+                        target: None,
+                    }),
+                    block: vec![],
+                    ws: Ws(Some(Whitespace::Preserve), Some(Whitespace::Suppress)),
+                },
+                Cond {
+                    test: None,
+                    block: vec![],
+                    ws: Ws(Some(Whitespace::Minimize), None),
+                },
+            ],
+            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+        )],
+    );
+}

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -1,17 +1,11 @@
 use crate::config::Syntax;
-use crate::parser::{Expr, Node, Whitespace, Ws};
+use crate::parser::{Expr, Lit, Node, Whitespace, Ws};
 
 fn check_ws_split(s: &str, res: &(&str, &str, &str)) {
-    match super::split_ws_parts(s) {
-        Node::Lit(lws, s, rws) => {
-            assert_eq!(lws, res.0);
-            assert_eq!(s, res.1);
-            assert_eq!(rws, res.2);
-        }
-        _ => {
-            panic!("fail");
-        }
-    }
+    let Lit { lws, val, rws } = super::split_ws_parts(s);
+    assert_eq!(lws, res.0);
+    assert_eq!(val, res.1);
+    assert_eq!(rws, res.2);
 }
 
 #[test]

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -688,3 +688,19 @@ fn test_parse_call_statement() {
         )],
     );
 }
+
+#[test]
+fn test_parse_macro_statement() {
+    use super::Macro;
+    let syntax = Syntax::default();
+    assert_eq!(
+        super::parse("{% macro foo(bar) -%}{%~ endmacro +%}", &syntax).unwrap(),
+        vec![Node::Macro(Macro {
+            name: "foo",
+            ws1: Ws(None, Some(Whitespace::Suppress)),
+            args: vec!["bar"],
+            nodes: vec![],
+            ws2: Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+        },)]
+    );
+}

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -733,14 +733,17 @@ fn test_parse_raw_block() {
 
 #[test]
 fn test_parse_block_def() {
+    use super::BlockDef;
     let syntax = Syntax::default();
     assert_eq!(
         super::parse("{% block foo -%}{%~ endblock +%}", &syntax).unwrap(),
         vec![Node::BlockDef(
-            Ws(None, Some(Whitespace::Suppress)),
-            "foo",
-            vec![],
-            Ws(Some(Whitespace::Minimize), Some(Whitespace::Preserve)),
+            Ws(None, Some(Whitespace::Preserve)),
+            BlockDef {
+                name: "foo",
+                block: vec![],
+                ws: Ws(Some(Whitespace::Minimize), Some(Whitespace::Suppress)),
+            }
         )],
     );
 }

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -652,6 +652,38 @@ fn test_parse_tuple() {
 }
 
 #[test]
+fn test_parse_loop() {
+    use super::{Expr, Loop, Target};
+    let syntax = Syntax::default();
+    assert_eq!(
+        super::parse("{% for user in users +%}{%~ else -%}{%+ endfor %}", &syntax).unwrap(),
+        vec![Node::Loop(Loop {
+            ws1: Ws(None, Some(Whitespace::Preserve)),
+            var: Target::Name("user"),
+            iter: Expr::Var("users"),
+            cond: None,
+            body: vec![],
+            ws2: Ws(Some(Whitespace::Minimize), Some(Whitespace::Suppress)),
+            else_block: vec![],
+            ws3: Ws(Some(Whitespace::Preserve), None),
+        })]
+    );
+    assert_eq!(
+        super::parse("{% for user in users +%}{%~ endfor -%}", &syntax).unwrap(),
+        vec![Node::Loop(Loop {
+            ws1: Ws(None, Some(Whitespace::Preserve)),
+            var: Target::Name("user"),
+            iter: Expr::Var("users"),
+            cond: None,
+            body: vec![],
+            ws2: Ws(Some(Whitespace::Minimize), None),
+            else_block: vec![],
+            ws3: Ws(None, Some(Whitespace::Suppress)),
+        })]
+    );
+}
+
+#[test]
 fn test_missing_space_after_kw() {
     let syntax = Syntax::default();
     let err = super::parse("{%leta=b%}", &syntax).unwrap_err();


### PR DESCRIPTION
This is the first set of changes extracted from #782.

These changes focus on clarifying the semantics of the whitespace of each `Node`.  This PR refrains from abstracting out the common whitespace-handling patterns that emerge here, leaving that for a follow-on PR.

We make the following changes here:

- Adding `Node` variant parsing tests
- (Mostly) consistently using one struct per `Node` variant
- Clarifying the semantics of each and every `Ws` value (though since the whitespace patterns aren't yet abstracted this clarification is still incomplete)

There should be no visible effects of these changes, they are purely distilling towards greater insight.  As described in the comments to #782, the general goal is to differentiate between the "inner" whitespace (within nested blocks) and the "outer" whitespace (around every node except lit).

Outer whitespace is the first field of each non-`Lit` variant of `Node`.  Inner whitespace is on each nested-block-type node, stored alongside the `Vec<Node>` value that represents the nested block.  For instance, for the template

```jinja
{%- if test +%}FooBar{%+ endif -%}
```

Would result in the Rust value

```rust
Node::Cond(
    Ws(Some(Whitespace::Suppress), Some(Whitespace::Suppress)),
    vec![
        Cond {
            test: CondTest {
                target: None,
                expr: Expr::Var("test"),
            },
            block: vec![Node::Lit("FooBar")],
            ws: Ws(Some(Whitespace::Preserve), Some(Whitespace::Preserve)),
        }
    ]
)
```

Thanks for your review, your time and effort are appreciated!