### PR TITLE
Document performance tips

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,3 +8,4 @@
 - [Template syntax](./template_syntax.md)
 - [Filters](./filters.md)
 - [Integrations](./integrations.md)
+- [Performance](./performance.md)

--- a/book/src/performance.md
+++ b/book/src/performance.md
@@ -1,0 +1,16 @@
+# Performance
+
+## Slow Debug Recompilations
+
+If you experience slow compile times when iterating with lots of templates,
+you can compile Askama's derive macros with a higher optimization level.
+This can speed up recompilation times dramatically.
+
+Add the following to `Cargo.toml` or `.cargo/config.toml`:
+```rust
+[profile.dev.package.askama_derive]
+opt-level = 3
+```
+
+This may affect clean compile times in debug mode, but incremental compiles
+will be faster.


### PR DESCRIPTION
Adds a new section to the book called `Performance`. Thought it might be nice to document this trick I stole from bevy, which can dramatically improve recompilation times when using many templates.

Follow-up to #828 and #826 