### PR TITLE
Parse templates once

### DIFF
--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_derive/src/parser/mod.rs
+++ b/askama_derive/src/parser/mod.rs
@@ -58,10 +58,7 @@ impl From<char> for Whitespace {
     }
 }
 
-pub(crate) fn parse<'a>(
-    src: &'a str,
-    syntax: &'a Syntax<'_>,
-) -> Result<Vec<Node<'a>>, CompileError> {
+pub(crate) fn parse<'a>(src: &'a str, syntax: &Syntax<'_>) -> Result<Vec<Node<'a>>, CompileError> {
     match Node::parse(src, &State::new(syntax)) {
         Ok((left, res)) => {
             if !left.is_empty() {


### PR DESCRIPTION
@Kijewski exactly the same idea (almost the same branch name, too)! You were faster, but this feels cleaner -- presumably your solution comes down to the same solution under the hood. At the cost of one instance of `unsafe`, but I feel pretty safe with this. What do you think?