### PR TITLE
Fix Rust macro invocations not accepting a path

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -1373,7 +1373,7 @@ impl<'a> Generator<'a> {
             }
             Expr::Group(ref inner) => self.visit_group(buf, inner)?,
             Expr::Call(ref obj, ref args) => self.visit_call(buf, obj, args)?,
-            Expr::RustMacro(name, args) => self.visit_rust_macro(buf, name, args),
+            Expr::RustMacro(ref path, args) => self.visit_rust_macro(buf, path, args),
             Expr::Try(ref expr) => self.visit_try(buf, expr.as_ref())?,
             Expr::Tuple(ref exprs) => self.visit_tuple(buf, exprs)?,
         })
@@ -1390,8 +1390,8 @@ impl<'a> Generator<'a> {
         Ok(DisplayWrap::Unwrapped)
     }
 
-    fn visit_rust_macro(&mut self, buf: &mut Buffer, name: &str, args: &str) -> DisplayWrap {
-        buf.write(name);
+    fn visit_rust_macro(&mut self, buf: &mut Buffer, path: &[&str], args: &str) -> DisplayWrap {
+        self.visit_path(buf, path);
         buf.write("!(");
         buf.write(args);
         buf.write(")");

--- a/askama_derive/src/parser/expr.rs
+++ b/askama_derive/src/parser/expr.rs
@@ -194,6 +194,7 @@ enum Suffix<'a> {
     Attr(&'a str),
     Index(Expr<'a>),
     Call(Vec<Expr<'a>>),
+    // The value is the arguments of the macro call.
     MacroCall(&'a str),
     Try,
 }

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -222,6 +222,25 @@ fn test_parse_root_path() {
 }
 
 #[test]
+fn test_parse_rust_macro() {
+    let syntax = Syntax::default();
+    assert_eq!(
+        super::parse("{{ vec!(1, 2, 3) }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::RustMacro(vec!["vec"], "1, 2, 3",),
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ alloc::vec!(1, 2, 3) }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::RustMacro(vec!["alloc", "vec"], "1, 2, 3",),
+        )],
+    );
+}
+
+#[test]
 fn change_delimiters_parse_filter() {
     let syntax = Syntax {
         expr_start: "{=",

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -222,7 +222,7 @@ fn test_parse_root_path() {
 }
 
 #[test]
-fn test_parse_rust_macro() {
+fn test_rust_macro() {
     let syntax = Syntax::default();
     assert_eq!(
         super::parse("{{ vec!(1, 2, 3) }}", &syntax).unwrap(),
@@ -237,6 +237,32 @@ fn test_parse_rust_macro() {
             Ws(None, None),
             Expr::RustMacro(vec!["alloc", "vec"], "1, 2, 3",),
         )],
+    );
+    assert_eq!(
+        super::parse("{{a!()}}", &syntax).unwrap(),
+        [Node::Expr(Ws(None, None), Expr::RustMacro(vec!["a"], ""))],
+    );
+    assert_eq!(
+        super::parse("{{a !()}}", &syntax).unwrap(),
+        [Node::Expr(Ws(None, None), Expr::RustMacro(vec!["a"], ""))],
+    );
+    assert_eq!(
+        super::parse("{{a! ()}}", &syntax).unwrap(),
+        [Node::Expr(Ws(None, None), Expr::RustMacro(vec!["a"], ""))],
+    );
+    assert_eq!(
+        super::parse("{{a ! ()}}", &syntax).unwrap(),
+        [Node::Expr(Ws(None, None), Expr::RustMacro(vec!["a"], ""))],
+    );
+    assert_eq!(
+        super::parse("{{A!()}}", &syntax).unwrap(),
+        [Node::Expr(Ws(None, None), Expr::RustMacro(vec!["A"], ""),)],
+    );
+    assert_eq!(
+        &*super::parse("{{a.b.c!( hello )}}", &syntax)
+            .unwrap_err()
+            .msg,
+        "problems parsing template source at row 1, column 7 near:\n\"!( hello )}}\"",
     );
 }
 

--- a/testing/templates/rust-macros-full-path.html
+++ b/testing/templates/rust-macros-full-path.html
@@ -1,1 +1,1 @@
-Hello, {{ foo::hello!() }}!
+Hello, {{ foo::hello2!() }}!

--- a/testing/templates/rust-macros-full-path.html
+++ b/testing/templates/rust-macros-full-path.html
@@ -1,0 +1,1 @@
+Hello, {{ foo::hello!() }}!

--- a/testing/tests/rust_macro.rs
+++ b/testing/tests/rust_macro.rs
@@ -16,6 +16,26 @@ fn main() {
     assert_eq!("Hello, world!", template.render().unwrap());
 }
 
+mod foo {
+    macro_rules! hello {
+        () => {
+            "world"
+        };
+    }
+
+    pub(crate) use hello;
+}
+
+#[derive(Template)]
+#[template(path = "rust-macros-full-path.html")]
+struct RustMacrosFullPathTemplate {}
+
+#[test]
+fn full_path() {
+    let template = RustMacrosFullPathTemplate {};
+    assert_eq!("Hello, world!", template.render().unwrap());
+}
+
 macro_rules! call_a_or_b_on_tail {
     ((a: $a:expr, b: $b:expr, c: $c:expr), call a: $($tail:expr),*) => {
         ($a)($($tail),*)

--- a/testing/tests/rust_macro.rs
+++ b/testing/tests/rust_macro.rs
@@ -17,13 +17,13 @@ fn main() {
 }
 
 mod foo {
-    macro_rules! hello {
+    macro_rules! hello2 {
         () => {
             "world"
         };
     }
 
-    pub(crate) use hello;
+    pub(crate) use hello2;
 }
 
 #[derive(Template)]

--- a/testing/tests/rust_macro.rs
+++ b/testing/tests/rust_macro.rs
@@ -11,7 +11,7 @@ macro_rules! hello {
 struct RustMacrosTemplate {}
 
 #[test]
-fn main() {
+fn macro_basic() {
     let template = RustMacrosTemplate {};
     assert_eq!("Hello, world!", template.render().unwrap());
 }
@@ -31,7 +31,7 @@ mod foo {
 struct RustMacrosFullPathTemplate {}
 
 #[test]
-fn full_path() {
+fn macro_full_path() {
     let template = RustMacrosFullPathTemplate {};
     assert_eq!("Hello, world!", template.render().unwrap());
 }
@@ -67,7 +67,7 @@ fn day(_: u16, _: &str, d: u8) -> u8 {
 struct RustMacrosArgTemplate {}
 
 #[test]
-fn args() {
+fn macro_with_args() {
     let template = RustMacrosArgTemplate {};
     assert_eq!("2021\nJuly\n2", template.render().unwrap());
 }


### PR DESCRIPTION
Fixes #836 

This just changes the RustMacro expression to accept a path, and runs it before `expr_path`, pretty simple small change. I did try making it a part of `expr_suffix`, but the parser would need to accept `!(...)` patterns, which seems to be much harder to parse correctly. This way also seems to be closer to how `rustc` parses macro invocations too.