### PR TITLE
Fix `clippy::items-after-test-module` error

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -171,6 +171,15 @@ impl fmt::Display for dyn DynTemplate {
     }
 }
 
+/// Old build script helper to rebuild crates if contained templates have changed
+///
+/// This function is now deprecated and does nothing.
+#[deprecated(
+    since = "0.8.1",
+    note = "file-level dependency tracking is handled automatically without build script"
+)]
+pub fn rerun_if_templates_changed() {}
+
 #[cfg(test)]
 mod tests {
     use std::fmt;
@@ -217,12 +226,3 @@ mod tests {
         assert_eq!(vec, vec![b't', b'e', b's', b't']);
     }
 }
-
-/// Old build script helper to rebuild crates if contained templates have changed
-///
-/// This function is now deprecated and does nothing.
-#[deprecated(
-    since = "0.8.1",
-    note = "file-level dependency tracking is handled automatically without build script"
-)]
-pub fn rerun_if_templates_changed() {}


### PR DESCRIPTION
A new clippy lint (items_after_test_module) was added in rust 1.71, which is causing builds to fail in the CI.