### PR TITLE
Fix parsing arrays

### DIFF
--- a/askama_derive/src/parser/expr.rs
+++ b/askama_derive/src/parser/expr.rs
@@ -4,7 +4,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till};
 use nom::character::complete::char;
 use nom::combinator::{cut, map, not, opt, peek, recognize};
-use nom::multi::{fold_many0, many0, separated_list0, separated_list1};
+use nom::multi::{fold_many0, many0, separated_list0};
 use nom::sequence::{delimited, pair, preceded, terminated, tuple};
 use nom::IResult;
 
@@ -124,10 +124,12 @@ fn expr_num_lit(i: &str) -> IResult<&str, Expr<'_>> {
 }
 
 fn expr_array_lit(i: &str) -> IResult<&str, Expr<'_>> {
-    delimited(
+    preceded(
         ws(char('[')),
-        map(separated_list1(ws(char(',')), expr_any), Expr::Array),
-        ws(char(']')),
+        cut(terminated(
+            map(separated_list0(char(','), ws(expr_any)), Expr::Array),
+            char(']'),
+        )),
     )(i)
 }
 

--- a/askama_derive/src/parser/tests.rs
+++ b/askama_derive/src/parser/tests.rs
@@ -666,3 +666,86 @@ fn test_missing_space_after_kw() {
         "unable to parse template:\n\n\"{%leta=b%}\""
     ));
 }
+
+#[test]
+fn test_parse_array() {
+    let syntax = Syntax::default();
+    assert_eq!(
+        super::parse("{{ [] }}", &syntax).unwrap(),
+        vec![Node::Expr(Ws(None, None), Expr::Array(vec![]))],
+    );
+    assert_eq!(
+        super::parse("{{ [1] }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1")])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ [ 1] }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1")])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ [1 ] }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1")])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ [1,2] }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1"), Expr::NumLit("2")])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ [1 ,2] }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1"), Expr::NumLit("2")])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ [1, 2] }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1"), Expr::NumLit("2")])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ [1,2 ] }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1"), Expr::NumLit("2")])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ []|foo }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Filter("foo", vec![Expr::Array(vec![])])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ []| foo }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Filter("foo", vec![Expr::Array(vec![])])
+        )],
+    );
+    assert_eq!(
+        super::parse("{{ [] |foo }}", &syntax).unwrap(),
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::BinOp(
+                "|",
+                Box::new(Expr::Array(vec![])),
+                Box::new(Expr::Var("foo"))
+            ),
+        )],
+    );
+}

--- a/testing/tests/ui/loop_cycle_empty.rs
+++ b/testing/tests/ui/loop_cycle_empty.rs
@@ -1,6 +1,3 @@
-// Nb. this test fails because currently an empty array "[]" is always a syntax error in askama,
-// but even if this changes, this test should keep failing, but possibly with another error message
-
 use askama::Template;
 
 #[derive(Template)]

--- a/testing/tests/ui/loop_cycle_empty.stderr
+++ b/testing/tests/ui/loop_cycle_empty.stderr
@@ -1,8 +1,7 @@
-error: problems parsing template source at row 1, column 34 near:
-       "([]) }}{{ v }},{% endfor %}"
- --> tests/ui/loop_cycle_empty.rs:6:10
+error: loop.cycle(…) cannot use an empty array
+ --> tests/ui/loop_cycle_empty.rs:3:10
   |
-6 | #[derive(Template)]
+3 | #[derive(Template)]
   |          ^^^^^^^^
   |
   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This change

* allows using empty arrays `[]` in expessions,
* adds a cut when the leading `[` was encountered, and
* fixes the interaction between arrays and boolean OR.

IMO the restriction that you couldn't use empty arrays is not needed. The missing cut made error messages slictly worse if you forget to add the closing `]`.

Filter expressions must not have white spaces before the pipe `|`. The white space is used to tell a filter expressions, and `std::ops::Or` apart.