### PR TITLE
Fix parsing calls

### DIFF
--- a/askama_parser/src/expr.rs
+++ b/askama_parser/src/expr.rs
@@ -5,8 +5,8 @@ use nom::bytes::complete::{tag, take_till};
 use nom::character::complete::char;
 use nom::combinator::{cut, map, not, opt, peek, recognize};
 use nom::error::ErrorKind;
-use nom::multi::{fold_many0, many0, separated_list0, separated_list1};
-use nom::sequence::{delimited, pair, preceded, terminated, tuple};
+use nom::multi::{fold_many0, many0, separated_list0};
+use nom::sequence::{pair, preceded, terminated, tuple};
 use nom::{error_position, IResult};
 
 use super::{bool_lit, char_lit, identifier, not_ws, num_lit, path, str_lit, ws};
@@ -177,10 +177,12 @@ impl<'a> Expr<'a> {
     }
 
     fn array(i: &'a str) -> IResult<&'a str, Self> {
-        delimited(
+        preceded(
             ws(char('[')),
-            map(separated_list1(ws(char(',')), Self::parse), Self::Array),
-            ws(char(']')),
+            cut(terminated(
+                map(separated_list0(char(','), ws(Self::parse)), Self::Array),
+                char(']'),
+            )),
         )(i)
     }
 

--- a/askama_parser/src/expr.rs
+++ b/askama_parser/src/expr.rs
@@ -68,10 +68,12 @@ pub enum Expr<'a> {
 
 impl<'a> Expr<'a> {
     pub(super) fn arguments(i: &'a str) -> IResult<&'a str, Vec<Self>> {
-        delimited(
+        preceded(
             ws(char('(')),
-            separated_list0(char(','), ws(Self::parse)),
-            ws(char(')')),
+            cut(terminated(
+                separated_list0(char(','), ws(Self::parse)),
+                char(')'),
+            )),
         )(i)
     }
 

--- a/askama_parser/src/tests.rs
+++ b/askama_parser/src/tests.rs
@@ -493,8 +493,33 @@ fn test_odd_calls() {
         Ast::from_str("{{ -a(b) }}", &syntax).unwrap().nodes,
         vec![Node::Expr(
             Ws(None, None),
-            Unary("-", Box::new(Call(Box::new(Var("a")), vec![Var("b")])),),
+            Unary("-", Box::new(Call(Box::new(Var("a")), vec![Var("b")]))),
         )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ a(b)|c }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Filter("c", vec![Call(Box::new(Var("a")), vec![Var("b")])]),
+        )]
+    );
+    assert_eq!(
+        Ast::from_str("{{ a(b)| c }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Filter("c", vec![Call(Box::new(Var("a")), vec![Var("b")])]),
+        )]
+    );
+    assert_eq!(
+        Ast::from_str("{{ a(b) |c }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            BinOp(
+                "|",
+                Box::new(Call(Box::new(Var("a")), vec![Var("b")])),
+                Box::new(Var("c"))
+            ),
+        )]
     );
 }
 

--- a/askama_parser/src/tests.rs
+++ b/askama_parser/src/tests.rs
@@ -761,3 +761,86 @@ fn test_missing_space_after_kw() {
         "unable to parse template:\n\n\"{%leta=b%}\""
     ));
 }
+
+#[test]
+fn test_parse_array() {
+    let syntax = Syntax::default();
+    assert_eq!(
+        Ast::from_str("{{ [] }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(Ws(None, None), Expr::Array(vec![]))],
+    );
+    assert_eq!(
+        Ast::from_str("{{ [1] }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1")])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ [ 1] }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1")])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ [1 ] }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1")])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ [1,2] }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1"), Expr::NumLit("2")])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ [1 ,2] }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1"), Expr::NumLit("2")])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ [1, 2] }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1"), Expr::NumLit("2")])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ [1,2 ] }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Array(vec![Expr::NumLit("1"), Expr::NumLit("2")])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ []|foo }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Filter("foo", vec![Expr::Array(vec![])])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ []| foo }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::Filter("foo", vec![Expr::Array(vec![])])
+        )],
+    );
+    assert_eq!(
+        Ast::from_str("{{ [] |foo }}", &syntax).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            Expr::BinOp(
+                "|",
+                Box::new(Expr::Array(vec![])),
+                Box::new(Expr::Var("foo"))
+            ),
+        )],
+    );
+}

--- a/testing/tests/ui/loop_cycle_empty.rs
+++ b/testing/tests/ui/loop_cycle_empty.rs
@@ -1,6 +1,3 @@
-// Nb. this test fails because currently an empty array "[]" is always a syntax error in askama,
-// but even if this changes, this test should keep failing, but possibly with another error message
-
 use askama::Template;
 
 #[derive(Template)]

--- a/testing/tests/ui/loop_cycle_empty.stderr
+++ b/testing/tests/ui/loop_cycle_empty.stderr
@@ -1,5 +1,5 @@
-error: problems parsing template source at row 1, column 34 near:
-       "([]) }}{{ v }},{% endfor %}"
+error: problems parsing template source at row 1, column 35 near:
+       "[]) }}{{ v }},{% endfor %}"
  --> tests/ui/loop_cycle_empty.rs:6:10
   |
 6 | #[derive(Template)]

--- a/testing/tests/ui/loop_cycle_empty.stderr
+++ b/testing/tests/ui/loop_cycle_empty.stderr
@@ -1,8 +1,7 @@
-error: problems parsing template source at row 1, column 35 near:
-       "[]) }}{{ v }},{% endfor %}"
- --> tests/ui/loop_cycle_empty.rs:6:10
+error: loop.cycle(…) cannot use an empty array
+ --> tests/ui/loop_cycle_empty.rs:3:10
   |
-6 | #[derive(Template)]
+3 | #[derive(Template)]
   |          ^^^^^^^^
   |
   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This change:

* adds a cut when the leading `(` was encountered, and
* fixed the interaction between call expressions and boolean OR.