### PR TITLE
fuzz: Add fuzz for askama_parser

### DIFF
--- a/askama_parser/fuzz/.gitignore
+++ b/askama_parser/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/askama_parser/fuzz/Cargo.toml
+++ b/askama_parser/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "askama_parser-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.askama_parser]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_parser"
+path = "fuzz_targets/fuzz_parser.rs"
+test = false
+doc = false

--- a/askama_parser/fuzz/README.md
+++ b/askama_parser/fuzz/README.md
@@ -1,0 +1,14 @@
+# Fuzzing
+
+Install `cargo-fuzz`:
+
+```sh
+cargo install -f cargo-fuzz
+```
+
+Run any available target where `$target` is the name of the target.
+
+```sh
+cargo fuzz list # get list of targets
+cargo +nightly fuzz run $target
+```

--- a/askama_parser/fuzz/fuzz_targets/fuzz_parser.rs
+++ b/askama_parser/fuzz/fuzz_targets/fuzz_parser.rs
@@ -1,0 +1,13 @@
+#![no_main]
+use askama_parser::*;
+use libfuzzer_sys::fuzz_target;
+use std::str;
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    if data.len() < 500 {
+        if let Ok(data) = str::from_utf8(data) {
+            if let Ok(_) = Ast::from_str(data, &Syntax::default()) {}
+        }
+    }
+});


### PR DESCRIPTION
Hi, I would like to help integrate this project into [OSS-Fuzz](https://github.com/google/oss-fuzz).

- As an initial step for integration I have created this PR: https://github.com/google/oss-fuzz/pull/10935, it contains necessary logic from an OSS-Fuzz perspective to integrate askama.

- OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects, you can find more details in our [FAQ](https://google.github.io/oss-fuzz/faq/).

Note:
 - This fuzz_target was able to find bug https://github.com/djc/askama/issues/860
 - I have limited input len to 500 as anything greater than that was resulting in stack-overflow which was crashing fuzz_target repeatedly.
