### PR TITLE
fuzz: remove input limit

### DIFF
--- a/askama_parser/fuzz/fuzz_targets/fuzz_parser.rs
+++ b/askama_parser/fuzz/fuzz_targets/fuzz_parser.rs
@@ -5,9 +5,7 @@ use std::str;
 
 fuzz_target!(|data: &[u8]| {
     // fuzzed code goes here
-    if data.len() < 500 {
-        if let Ok(data) = str::from_utf8(data) {
-            if let Ok(_) = Ast::from_str(data, &Syntax::default()) {}
-        }
+    if let Ok(data) = str::from_utf8(data) {
+        if let Ok(_) = Ast::from_str(data, &Syntax::default()) {}
     }
 });


### PR DESCRIPTION
While working on https://github.com/djc/askama/pull/862 fuzz_parser was crashing and failing oss-fuzz build_checks. so a limit of 500 was placed, this pr removes that.