### PR TITLE
Limit expression nesting level to avoid stack overflows

### DIFF
--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -15,6 +15,7 @@ use super::{
     bool_lit, char_lit, identifier, is_ws, keyword, num_lit, path_or_identifier, skip_till,
     str_lit, ws, Expr, PathOrIdentifier, State,
 };
+use crate::expr::Level;
 
 #[derive(Debug, PartialEq)]
 pub enum Node<'a> {
@@ -536,7 +537,7 @@ impl<'a> Call<'a> {
             cut(tuple((
                 opt(tuple((ws(identifier), ws(tag("::"))))),
                 ws(identifier),
-                opt(ws(Expr::arguments)),
+                opt(ws(|nested| Expr::arguments(nested, Level::default()))),
                 opt(Whitespace::parse),
             ))),
         ));


### PR DESCRIPTION
This is triggered by the fuzzer, see also https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62759.