### PR TITLE
Yield a parser error when defining a macro named 'super'

### DIFF
--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -474,16 +474,17 @@ impl<'a> Macro<'a> {
         )));
         let (i, (contents, (_, pws2, _, nws2))) = end(i)?;
 
-        assert_ne!(name, "super", "invalid macro name 'super'");
-
-        let params = params.unwrap_or_default();
+        if name == "super" {
+            // TODO: yield a a better error message here
+            return Err(nom::Err::Failure(Error::new(i, ErrorKind::Fail)));
+        }
 
         Ok((
             i,
             Self {
                 ws1: Ws(pws1, nws1),
                 name,
-                args: params,
+                args: params.unwrap_or_default(),
                 nodes: contents,
                 ws2: Ws(pws2, nws2),
             },

--- a/askama_parser/src/tests.rs
+++ b/askama_parser/src/tests.rs
@@ -795,3 +795,9 @@ fn fuzzed_unicode_slice() {
             0!(!1q҄א!)!!!!!!n!";
     assert!(Ast::from_str(d, &Syntax::default()).is_err());
 }
+
+#[test]
+fn fuzzed_macro_no_end() {
+    let s = "{%macro super%}{%endmacro";
+    assert!(Ast::from_str(s, &Syntax::default()).is_err());
+}


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62773