### PR TITLE
Allow macros to take `self` as an argument

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -952,7 +952,7 @@ impl<'a> Generator<'a> {
                 // If `expr` is already a form of variable then
                 // don't reintroduce a new variable. This is
                 // to avoid moving non-copyable values.
-                Expr::Var(name) => {
+                &Expr::Var(name) if name != "self" => {
                     let var = self.locals.resolve_or_self(name);
                     self.locals.insert(arg, LocalMeta::with_ref(var));
                 }

--- a/testing/templates/macro-self-arg.html
+++ b/testing/templates/macro-self-arg.html
@@ -1,0 +1,5 @@
+{%- macro my_s(slf) -%}
+    {{ slf.s }}
+{%- endmacro -%}
+
+{%- call my_s(self) -%}

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -83,3 +83,15 @@ fn str_cmp() {
     let t = StrCmpTemplate;
     assert_eq!(t.render().unwrap(), "AfooBotherCneitherD");
 }
+
+#[derive(Template)]
+#[template(path = "macro-self-arg.html")]
+struct MacroSelfArgTemplate<'a> {
+    s: &'a str,
+}
+
+#[test]
+fn test_macro_self_arg() {
+    let t = MacroSelfArgTemplate { s: "foo" };
+    assert_eq!(t.render().unwrap(), "foo");
+}


### PR DESCRIPTION
Fixes the error ``no field `self` on type `&Templ` `` in the following example

```rust
#[derive(askama::Template)]
#[template(
    ext = "html",
    source = "
        {% macro m(x) %}
            {{ x.name }}
        {% endmacro %}

        {# this doesn't work #}
        {% call m(self) %}
    "
)]
struct Templ {
    name: String,
}

fn main() {
    println!(
        "{}",
        Templ {
            name: "Templ".into()
        }
    );
}
```
