### PR TITLE
Improve error message for incompatible names in `endmacro` and `endblock`

### DIFF
--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -101,7 +101,7 @@ impl<'a> Ast<'a> {
         let msg = format!(
             "{}problems parsing template source at row {}, column {} near:\n{}",
             if let Some(message) = message {
-                format!("error: {message}\n")
+                format!("{message}\n")
             } else {
                 String::new()
             },

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -484,7 +484,13 @@ impl<'a> Macro<'a> {
                 |i| s.tag_block_start(i),
                 opt(Whitespace::parse),
                 ws(keyword("endmacro")),
-                cut(preceded(ws(opt(keyword(name))), opt(Whitespace::parse))),
+                cut(preceded(
+                    opt(|before| {
+                        let (after, end_name) = ws(identifier)(before)?;
+                        check_end_name(before, after, name, end_name, "macro")
+                    }),
+                    opt(Whitespace::parse),
+                )),
             ))),
         )));
         let (i, (contents, (_, pws2, _, nws2))) = end(i)?;

--- a/testing/tests/ui/name_mismatch_endblock.stderr
+++ b/testing/tests/ui/name_mismatch_endblock.stderr
@@ -1,4 +1,5 @@
-error: problems parsing template source at row 1, column 27 near:
+error: expected name `foo` in `endblock` tag, found `not_foo`
+       problems parsing template source at row 1, column 27 near:
        "not_foo %}"
  --> tests/ui/name_mismatch_endblock.rs:3:10
   |

--- a/testing/tests/ui/name_mismatch_endmacro.stderr
+++ b/testing/tests/ui/name_mismatch_endmacro.stderr
@@ -1,4 +1,5 @@
-error: problems parsing template source at row 1, column 41 near:
+error: expected name `foo` in `endmacro` tag, found `not_foo`
+       problems parsing template source at row 1, column 41 near:
        "not_foo %}"
  --> tests/ui/name_mismatch_endmacro.rs:3:10
   |


### PR DESCRIPTION
To achieve this, I needed to completely change how errors were handled and to create a new type (`ParsingError`). Thanks to this, we can now add custom error messages. I'm planning to iterate on this base to provide better error messages overall and potentially even suggestion (like when the parser encounters `elif` so it can suggest to use `else if` instead).