### PR TITLE
Improve `elif` error

### DIFF
--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -299,7 +299,15 @@ impl<'a> Cond<'a> {
         let mut p = tuple((
             |i| s.tag_block_start(i),
             opt(Whitespace::parse),
-            ws(keyword("else")),
+            ws(alt((keyword("else"), |i| {
+                let _ = keyword("elif")(i)?;
+                Err(nom::Err::Failure(ErrorContext {
+                    input: i,
+                    message: Some(Cow::Borrowed(
+                        "unknown `elif` keyword; did you mean `else if`?",
+                    )),
+                }))
+            }))),
             cut(tuple((
                 opt(|i| CondTest::parse(i, s)),
                 opt(Whitespace::parse),

--- a/testing/tests/ui/elif.rs
+++ b/testing/tests/ui/elif.rs
@@ -1,0 +1,8 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(source = "{% if true %}{% elif false %}{% endif %}", ext = "html")]
+struct UnknownElif;
+
+fn main() {
+}

--- a/testing/tests/ui/elif.stderr
+++ b/testing/tests/ui/elif.stderr
@@ -1,0 +1,9 @@
+error: unknown `elif` keyword; did you mean `else if`?
+       problems parsing template source at row 1, column 16 near:
+       "elif false %}{% endif %}"
+ --> tests/ui/elif.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
It's based on https://github.com/djc/askama/pull/887 (only the two last commits are from this PR).

When switching from another jinja-like framework, it's frequent to forget keywords like `elif`, so instead of just throwing a generic error, it also suggests `else if`.