### PR TITLE
Derive Clone for Expr and Target

### DIFF
--- a/askama_parser/src/expr.rs
+++ b/askama_parser/src/expr.rs
@@ -49,7 +49,7 @@ macro_rules! expr_prec_layer {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Expr<'a> {
     BoolLit(&'a str),
     NumLit(&'a str),

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -118,7 +118,7 @@ impl<'a> Node<'a> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Target<'a> {
     Name(&'a str),
     Tuple(Vec<&'a str>, Vec<Target<'a>>),


### PR DESCRIPTION
When working with an `askama` AST I frequently find myself wishing for these `Clone` implementations.

c.f. the Rust API guidelines [C-COMMON-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits)