### PR TITLE
Add better support for rust-like number literals

### DIFF
--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -302,7 +302,7 @@ fn num_lit(i: &str) -> ParseResult<'_> {
     )))(i)
 }
 
-/// Underscore separateed digits of the given base, unless `start` is true this may start
+/// Underscore separated digits of the given base, unless `start` is true this may start
 /// with an underscore.
 fn separated_digits(radix: u32, start: bool) -> impl Fn(&str) -> ParseResult<'_> {
     move |i| {

--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -272,7 +272,7 @@ fn num_lit(i: &str) -> ParseResult<'_> {
                     recognize(tuple((
                         char('x'),
                         many0_count(char('_')),
-                        satisfy(|ch| matches!(ch, '0'..='9' | 'a'..='f' | 'A'..='F')),
+                        satisfy(|ch| ch.is_ascii_hexdigit()),
                         many0_count(satisfy(
                             |ch| matches!(ch, '_' | '0'..='9' | 'a'..='f' | 'A'..='F'),
                         )),
@@ -294,7 +294,7 @@ fn num_lit(i: &str) -> ParseResult<'_> {
                 ))),
             ))),
             recognize(tuple((
-                satisfy(|ch| matches!(ch, '0'..='9')),
+                satisfy(|ch| ch.is_ascii_digit()),
                 many0_count(satisfy(|ch| matches!(ch, '_' | '0'..='9'))),
                 opt(alt((
                     tag("i8"),
@@ -314,19 +314,19 @@ fn num_lit(i: &str) -> ParseResult<'_> {
                     recognize(tuple((
                         opt(tuple((
                             char('.'),
-                            satisfy(|ch| matches!(ch, '0'..='9')),
+                            satisfy(|ch| ch.is_ascii_digit()),
                             many0_count(satisfy(|ch| matches!(ch, '_' | '0'..='9'))),
                         ))),
                         one_of("eE"),
                         opt(one_of("+-")),
                         many0_count(char('_')),
-                        satisfy(|ch| matches!(ch, '0'..='9')),
+                        satisfy(|ch| ch.is_ascii_digit()),
                         many0_count(satisfy(|ch| matches!(ch, '_' | '0'..='9'))),
                         opt(alt((tag("f32"), tag("f64")))),
                     ))),
                     recognize(tuple((
                         char('.'),
-                        satisfy(|ch| matches!(ch, '0'..='9')),
+                        satisfy(|ch| ch.is_ascii_digit()),
                         many0_count(satisfy(|ch| matches!(ch, '_' | '0'..='9'))),
                         opt(alt((tag("f32"), tag("f64")))),
                     ))),

--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -298,7 +298,7 @@ fn num_lit(i: &str) -> ParseResult<'_> {
                 opt(integer_suffix_tags),
             ))),
             recognize(tuple((
-                separated_digits(10, false),
+                separated_digits(10, true),
                 opt(alt((
                     integer_suffix_tags,
                     float_suffix_tags,

--- a/testing/templates/num-literals.html
+++ b/testing/templates/num-literals.html
@@ -1,0 +1,11 @@
+{% let plain_int = 9__0__ -%}
+{% let neg_int = -9__0__isize -%}
+{% let suffix_int = 9__0__i32 -%}
+{% let bin_int = 0b__1__0__ -%}
+{% let oct_int = 0o__7__0__ -%}
+{% let hex_int = 0x__f__0__ -%}
+{% let plain_float = 1__0__.5__0__ -%}
+{% let suffix_float = 1__0__.5__0__f32 -%}
+{% let exp_float = 1__0__e+__1__0__f32 -%}
+{% let dotexp_float = 1__0__.5__0__e+__1__0__f32 -%}
+[{{ plain_int }}, {{ neg_int }}, {{ suffix_int }}, {{ bin_int }}, {{ oct_int }}, {{ hex_int }}, {{ plain_float }}, {{ suffix_float }}, {{ exp_float }}, {{ dotexp_float }}]

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -461,3 +461,26 @@ fn test_define_string_var() {
     let template = DefineStringVar;
     assert_eq!(template.render().unwrap(), "");
 }
+
+#[derive(askama::Template)]
+#[template(source = "{% let x = 4.5 %}{{ x }}", ext = "html")]
+struct SimpleFloat;
+
+#[test]
+fn test_simple_float() {
+    let template = SimpleFloat;
+    assert_eq!(template.render().unwrap(), "4.5");
+}
+
+#[derive(askama::Template)]
+#[template(path = "num-literals.html")]
+struct NumLiterals;
+
+#[test]
+fn test_num_literals() {
+    let template = NumLiterals;
+    assert_eq!(
+        template.render().unwrap(),
+        "[90, -90, 90, 2, 56, 240, 10.5, 10.5, 100000000000, 105000000000]",
+    );
+}


### PR DESCRIPTION
Added support for underscore separators, scientific notation and suffixes (e.g. `usize` or `f64`) for numbers.
Alleviates issue #882 for number literals.