### PR TITLE
Allow to pass named arguments to macro calls

### DIFF
--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -564,7 +564,7 @@ impl<'a> Call<'a> {
             cut(tuple((
                 opt(tuple((ws(identifier), ws(tag("::"))))),
                 ws(identifier),
-                opt(ws(|nested| Expr::arguments(nested, s.level.get()))),
+                opt(ws(|nested| Expr::arguments(nested, s.level.get(), true))),
                 opt(Whitespace::parse),
             ))),
         ));

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -564,7 +564,7 @@ You can define macros within your template by using `{% macro name(args) %}`, en
 
 You can then call it with `{% call name(args) %}`:
 
-```
+```jinja
 {% macro heading(arg) %}
 
 <h1>{{arg}}</h1>
@@ -576,7 +576,7 @@ You can then call it with `{% call name(args) %}`:
 
 You can place macros in a separate file and use them in your templates by using `{% import %}`:
 
-```
+```jinja
 {%- import "macro.html" as scope -%}
 
 {% call scope::heading(s) %}
@@ -584,6 +584,51 @@ You can place macros in a separate file and use them in your templates by using 
 
 You can optionally specify the name of the macro in `endmacro`:
 
-```html
+```jinja
 {% macro heading(arg) %}<p>{{arg}}</p>{% endmacro heading %}
+```
+
+You can also specify arguments by their name (as defined in the macro):
+
+```jinja
+{% macro heading(arg, bold) %}
+
+<h1>{{arg}} <b>{{bold}}</b></h1>
+
+{% endmacro %}
+
+{% call heading(bold="something", arg="title") %}
+```
+
+You can use whitespace characters around `=`:
+
+```jinja
+{% call heading(bold = "something", arg = "title") %}
+```
+
+You can mix named and non-named arguments when calling a macro:
+
+```
+{% call heading("title", bold="something") %}
+```
+
+However please note than named arguments must always come **last**.
+
+Another thing to note, if a named argument is referring to an argument that would
+be used for a non-named argument, it will error:
+
+```jinja
+{% macro heading(arg1, arg2, arg3, arg4) %}
+{% endmacro %}
+
+{% call heading("something", "b", arg4="ah", arg2="title") %}
+```
+
+In here it's invalid because `arg2` is the second argument and would be used by
+`"b"`. So either you replace `"b"` with `arg3="b"` or you pass `"title"` before:
+
+```jinja
+{% call heading("something", arg3="b", arg4="ah", arg2="title") %}
+{# Equivalent of: #}
+{% call heading("something", "title", "b", arg4="ah") %}
 ```

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -95,3 +95,31 @@ fn test_macro_self_arg() {
     let t = MacroSelfArgTemplate { s: "foo" };
     assert_eq!(t.render().unwrap(), "foo");
 }
+
+#[derive(Template)]
+#[template(
+    source = "{%- macro thrice(param1, param2) -%}
+{{ param1 }} {{ param2 }}
+{% endmacro -%}
+
+{%- call thrice(param1=2, param2=3) -%}
+{%- call thrice(param2=3, param1=2) -%}
+{%- call thrice(3, param2=2) -%}
+",
+    ext = "html"
+)]
+struct MacroNamedArg;
+
+#[test]
+// We check that it's always the correct values passed to the
+// expected argument.
+fn test_named_argument() {
+    assert_eq!(
+        MacroNamedArg.render().unwrap(),
+        "\
+2 3
+2 3
+3 2
+"
+    );
+}

--- a/testing/tests/ui/macro_named_argument.rs
+++ b/testing/tests/ui/macro_named_argument.rs
@@ -1,0 +1,45 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(source = "{%- macro thrice(param1, param2) -%}
+{{ param1 }} {{ param2 }}
+{%- endmacro -%}
+
+{%- call thrice(param1=2, param3=3) -%}", ext = "html")]
+struct InvalidNamedArg;
+
+#[derive(Template)]
+#[template(source = "{%- macro thrice(param1, param2) -%}
+{{ param1 }} {{ param2 }}
+{%- endmacro -%}
+
+{%- call thrice(param1=2, param1=3) -%}", ext = "html")]
+struct InvalidNamedArg2;
+
+// Ensures that filters can't have named arguments.
+#[derive(Template)]
+#[template(source = "{%- macro thrice(param1, param2) -%}
+{{ param1 }} {{ param2 }}
+{%- endmacro -%}
+
+{%- call thrice(3, param1=2) | filter(param1=12) -%}", ext = "html")]
+struct InvalidNamedArg3;
+
+// Ensures that named arguments can only be passed last.
+#[derive(Template)]
+#[template(source = "{%- macro thrice(param1, param2) -%}
+{{ param1 }} {{ param2 }}
+{%- endmacro -%}
+{%- call thrice(param1=2, 3) -%}", ext = "html")]
+struct InvalidNamedArg4;
+
+// Ensures that named arguments can't be used for arguments before them.
+#[derive(Template)]
+#[template(source = "{%- macro thrice(param1, param2) -%}
+{{ param1 }} {{ param2 }}
+{%- endmacro -%}
+{%- call thrice(3, param1=2) -%}", ext = "html")]
+struct InvalidNamedArg5;
+
+fn main() {
+}

--- a/testing/tests/ui/macro_named_argument.stderr
+++ b/testing/tests/ui/macro_named_argument.stderr
@@ -1,0 +1,44 @@
+error: no argument named `param3` in macro "thrice"
+ --> tests/ui/macro_named_argument.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: named argument `param1` was passed more than once
+       problems parsing template source at row 5, column 15 near:
+       "(param1=2, param1=3) -%}"
+  --> tests/ui/macro_named_argument.rs:11:10
+   |
+11 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: problems parsing template source at row 5, column 29 near:
+       "| filter(param1=12) -%}"
+  --> tests/ui/macro_named_argument.rs:20:10
+   |
+20 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: named arguments must always be passed last
+       problems parsing template source at row 4, column 15 near:
+       "(param1=2, 3) -%}"
+  --> tests/ui/macro_named_argument.rs:29:10
+   |
+29 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot have unnamed argument (`param2`) after named argument in macro "thrice"
+  --> tests/ui/macro_named_argument.rs:37:10
+   |
+37 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Fixes #885.

Based on https://github.com/djc/askama/pull/909 (so only the last 3 commits are relevant to this PR).

I made a very permissive implementation which allows to mix named and non-named arguments. The only thing we need to check outside of the parser is that the named arguments actually have an equivalent in the called macro. For the rest, everything is checked in the parser directly, which allows nicer error messages.