### PR TITLE
Allow `extends`, `macro` and `import` inside an included template

### DIFF
--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -35,6 +35,7 @@ impl Heritage<'_> {
 
 type BlockAncestry<'a> = HashMap<&'a str, Vec<(&'a Context<'a>, &'a BlockDef<'a>)>>;
 
+#[derive(Clone)]
 pub(crate) struct Context<'a> {
     pub(crate) nodes: &'a [Node<'a>],
     pub(crate) extends: Option<PathBuf>,

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -119,8 +119,13 @@ impl TemplateInput<'_> {
             while let Some(nodes) = nested.pop() {
                 for n in nodes {
                     let mut add_to_check = |path: PathBuf| -> Result<(), CompileError> {
-                        let source = get_template_source(&path)?;
-                        check.push((path, source));
+                        if !map.contains_key(&path) {
+                            // Add a dummy entry to `map` in order to prevent adding `path`
+                            // multiple times to `check`.
+                            map.insert(path.clone(), Parsed::default());
+                            let source = get_template_source(&path)?;
+                            check.push((path, source));
+                        }
                         Ok(())
                     };
 

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -114,8 +114,9 @@ impl TemplateInput<'_> {
         while let Some((path, source)) = check.pop() {
             let parsed = Parsed::new(source, self.syntax)?;
             for n in parsed.nodes() {
+                use Node::*;
                 match n {
-                    Node::Extends(extends) => {
+                    Extends(extends) => {
                         let extends = self.config.find_template(extends.path, Some(&path))?;
                         let dependency_path = (path.clone(), extends.clone());
                         if dependency_graph.contains(&dependency_path) {
@@ -132,12 +133,25 @@ impl TemplateInput<'_> {
                         let source = get_template_source(&extends)?;
                         check.push((extends, source));
                     }
-                    Node::Import(import) => {
+                    Import(import) => {
                         let import = self.config.find_template(import.path, Some(&path))?;
                         let source = get_template_source(&import)?;
                         check.push((import, source));
                     }
-                    _ => {}
+                    If(_)
+                    | Loop(_)
+                    | Match(_)
+                    | BlockDef(_)
+                    | Include(_)
+                    | Lit(_)
+                    | Comment(_)
+                    | Expr(_, _)
+                    | Call(_)
+                    | Let(_)
+                    | Macro(_)
+                    | Raw(_)
+                    | Continue(_)
+                    | Break(_) => {}
                 }
             }
             map.insert(path, parsed);

--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -28,6 +28,7 @@ mod _parsed {
     use super::node::Node;
     use super::{Ast, ParseError, Syntax};
 
+    #[derive(Default)]
     pub struct Parsed {
         // `source` must outlive `ast`, so `ast` must be declared before `source`
         ast: Ast<'static>,
@@ -68,7 +69,7 @@ mod _parsed {
 
 pub use _parsed::Parsed;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Ast<'a> {
     nodes: Vec<Node<'a>>,
 }

--- a/testing/templates/include-extends-base.html
+++ b/testing/templates/include-extends-base.html
@@ -1,0 +1,6 @@
+<div>
+    <p>Below me is the header</p>
+    {% block header %}{% endblock %}
+    <p>Above me is the header</p>
+</div>
+Hello, {{ name }}!

--- a/testing/templates/include-extends-included.html
+++ b/testing/templates/include-extends-included.html
@@ -1,0 +1,2 @@
+{% extends "include-extends-base.html" %}
+{% block header %}foo{% endblock %}

--- a/testing/templates/include-extends.html
+++ b/testing/templates/include-extends.html
@@ -1,0 +1,4 @@
+<div>
+    <h1>Welcome</h1>
+    {% include "include-extends-included.html" %}
+</div>

--- a/testing/templates/include-macro.html
+++ b/testing/templates/include-macro.html
@@ -1,0 +1,4 @@
+{% macro m(name) -%}
+    Hello, {{ name }}!
+{%- endmacro -%}
+{% include "included-macro.html" %}

--- a/testing/templates/included-macro.html
+++ b/testing/templates/included-macro.html
@@ -1,0 +1,6 @@
+{% macro m2(name) -%}
+    Howdy, {{ name }}!
+{%- endmacro -%}
+
+{% call m(name) %}
+{% call m2(name2) %}

--- a/testing/tests/include.rs
+++ b/testing/tests/include.rs
@@ -12,3 +12,44 @@ fn test_include() {
     let s = IncludeTemplate { strs: &strs };
     assert_eq!(s.render().unwrap(), "\n  INCLUDED: foo\n  INCLUDED: bar")
 }
+
+#[derive(Template)]
+#[template(path = "include-extends.html")]
+struct IncludeExtendsTemplate<'a> {
+    name: &'a str,
+}
+
+#[test]
+fn test_include_extends() {
+    let template = IncludeExtendsTemplate { name: "Alice" };
+
+    assert_eq!(
+        template.render().unwrap(),
+        "<div>\n    \
+         <h1>Welcome</h1>\n    \
+         <div>\n    \
+         <p>Below me is the header</p>\n    \
+         foo\n    \
+         <p>Above me is the header</p>\n\
+         </div>\n\
+         Hello, Alice!\n\
+         </div>"
+    );
+}
+
+#[derive(Template)]
+#[template(path = "include-macro.html")]
+struct IncludeMacroTemplate<'a> {
+    name: &'a str,
+    name2: &'a str,
+}
+
+#[test]
+fn test_include_macro() {
+    let template = IncludeMacroTemplate {
+        name: "Alice",
+        name2: "Bob",
+    };
+
+    assert_eq!(template.render().unwrap(), "Hello, Alice!\nHowdy, Bob!");
+}


### PR DESCRIPTION
This makes `include` work [more like in Jinja2 ](https://jinja.palletsprojects.com/en/3.1.x/templates/#include), and closes (#572).
This also improves caching of included templates by storing them inside the `contexts` map.