### PR TITLE
Add support for `{% if var is [not] defined %}` statements

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -480,7 +480,8 @@ impl<'a> Generator<'a> {
                 syn::Data::Struct(s) => s
                     .fields
                     .iter()
-                    .any(|field| field.ident.as_ref().is_some_and(|f| f == name)),
+                    .filter_map(|f| f.ident.as_ref())
+                    .any(|f| f == name),
                 _ => false,
             }
         }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -515,7 +515,7 @@ impl<'a> Generator<'a> {
                     if is_first {
                         buf.write("if ");
                     } else {
-                        buf.dedent()?; // {
+                        buf.dedent()?;
                         buf.write("} else if ");
                     }
                     is_last = false;
@@ -543,7 +543,7 @@ impl<'a> Generator<'a> {
                 }
                 &Some(CondTest::Defined { name, not }) if not != self.has_local(name) => {
                     if !is_first {
-                        buf.dedent()?; // {
+                        buf.dedent()?;
                         buf.write("} else");
                     }
                     has_else = true;
@@ -555,7 +555,7 @@ impl<'a> Generator<'a> {
                 }
                 None => {
                     if !is_first {
-                        buf.dedent()?; // {
+                        buf.dedent()?;
                         buf.write("} else");
                     }
                     has_else = true;
@@ -565,7 +565,7 @@ impl<'a> Generator<'a> {
             }
 
             if !is_first {
-                buf.writeln(" {")?; // }
+                buf.writeln(" {")?;
 
                 arm_size += self.handle(ctx, &cond.nodes, buf, AstLevel::Nested)?;
                 arm_sizes.push(arm_size);

--- a/testing/templates/if-defined.html
+++ b/testing/templates/if-defined.html
@@ -1,0 +1,9 @@
+{%- if name is defined -%}
+    Hello {{ name }}!
+{%- else if !cond -%}
+    !cond
+{%- else if other_name is not defined -%}
+    Both names aren't defined
+{%- else -%}
+    Aloha {{ other_name }}!
+{%- endif -%}

--- a/testing/templates/include-if-defined.html
+++ b/testing/templates/include-if-defined.html
@@ -1,0 +1,7 @@
+{% if let Some(other_name) = my_other_name %}
+    {%- include "if-defined.html" -%}
+{% else if let Some(name) = my_name %}
+    {%- include "if-defined.html" -%}
+{% else %}
+    {%- include "if-defined.html" -%}
+{% endif %}

--- a/testing/tests/if_defined.rs
+++ b/testing/tests/if_defined.rs
@@ -1,0 +1,65 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(path = "if-defined.html")]
+struct IfDefined<'a> {
+    name: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "if-defined.html")]
+struct IfNotDefined {
+    cond: bool,
+}
+
+#[derive(Template)]
+#[template(path = "if-defined.html")]
+struct IfOtherDefined<'a> {
+    cond: bool,
+    other_name: &'a str,
+}
+
+#[test]
+fn test_if_defined() {
+    let t = IfDefined { name: "Alice" };
+    assert_eq!(t.render().unwrap(), "Hello Alice!");
+    let t = IfNotDefined { cond: false };
+    assert_eq!(t.render().unwrap(), "!cond");
+    let t = IfNotDefined { cond: true };
+    assert_eq!(t.render().unwrap(), "Both names aren't defined");
+    let t = IfOtherDefined {
+        cond: true,
+        other_name: "Bob",
+    };
+    assert_eq!(t.render().unwrap(), "Aloha Bob!");
+}
+
+#[derive(Template)]
+#[template(path = "include-if-defined.html")]
+struct IncludeIfDefined<'a> {
+    cond: bool,
+    my_name: Option<&'a str>,
+    my_other_name: Option<&'a str>,
+}
+
+#[test]
+fn test_include_if_defined() {
+    let t = IncludeIfDefined {
+        cond: false,
+        my_name: Some("Alice"),
+        my_other_name: None,
+    };
+    assert_eq!(t.render().unwrap(), "Hello Alice!");
+    let t = IncludeIfDefined {
+        cond: true,
+        my_name: None,
+        my_other_name: Some("Bob"),
+    };
+    assert_eq!(t.render().unwrap(), "Aloha Bob!");
+    let t = IncludeIfDefined {
+        cond: true,
+        my_name: None,
+        my_other_name: None,
+    };
+    assert_eq!(t.render().unwrap(), "Both names aren't defined");
+}

--- a/testing/tests/if_defined.rs
+++ b/testing/tests/if_defined.rs
@@ -35,6 +35,19 @@ fn test_if_defined() {
 }
 
 #[derive(Template)]
+#[template(
+    source = "Hello{% if name is defined %}, {{ name }}{% endif %}!",
+    ext = "txt"
+)]
+struct UngeneratedIfDefined;
+
+#[test]
+fn test_ungenerated_if_defined() {
+    let t = UngeneratedIfDefined;
+    assert_eq!(t.render().unwrap(), "Hello!");
+}
+
+#[derive(Template)]
 #[template(path = "include-if-defined.html")]
 struct IncludeIfDefined<'a> {
     cond: bool,


### PR DESCRIPTION
Implements compile time checking of whether a variable is defined in an `if` statement, which can be useful for `include` statements. Closes #257.

```jinja
{%- if name is defined -%}
    Hello {{ name }}!
{%- else if other_name is not defined -%}
    Both names aren't defined
{%- else -%}
    Aloha {{ other_name }}!
{%- endif -%}
```