### PR TITLE
Add checking for declaration of reserved variable names (`writer` and `self`)

### DIFF
--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -135,7 +135,6 @@ pub(crate) type ParseResult<'a, T = &'a str> = Result<(&'a str, T), nom::Err<Err
 ///
 /// It cannot be used to replace `ParseError` because it expects a generic, which would make
 /// `askama`'s users experience less good (since this generic is only needed for `nom`).
-#[derive(Debug)]
 pub(crate) struct ErrorContext<'a> {
     pub(crate) input: &'a str,
     pub(crate) message: Option<Cow<'static, str>>,


### PR DESCRIPTION
Check for declaration of variables named `writer` or `self` when parsing a target, and error if found.