### PR TITLE
Allow trailing comma in macro definition and call

### DIFF
--- a/askama_parser/src/expr.rs
+++ b/askama_parser/src/expr.rs
@@ -119,7 +119,7 @@ impl<'a> Expr<'a> {
                         }
                     }),
                 ),
-                char(')'),
+                tuple((opt(ws(char(','))), char(')'))),
             )),
         )(i)
     }

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -493,7 +493,7 @@ impl<'a> Macro<'a> {
             delimited(
                 ws(char('(')),
                 separated_list0(char(','), ws(identifier)),
-                ws(char(')')),
+                tuple((opt(ws(char(','))), char(')'))),
             )(i)
         }
 

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -140,3 +140,33 @@ struct OnlyNamedArgument;
 fn test_only_named_argument() {
     assert_eq!(OnlyNamedArgument.render().unwrap(), "hi");
 }
+
+// Check for trailing commas.
+#[derive(Template)]
+#[template(
+    source = r#"{% macro button(label , ) %}
+{{- label -}}
+{% endmacro %}
+{%- macro button2(label ,) %}
+{% endmacro %}
+{%- macro button3(label,) %}
+{% endmacro %}
+{%- macro button4(label, ) %}
+{% endmacro %}
+{%- macro button5(label ) %}
+{% endmacro %}
+
+{%- call button(label="hi" , ) -%}
+{%- call button(label="hi" ,) -%}
+{%- call button(label="hi",) -%}
+{%- call button(label="hi", ) -%}
+{%- call button(label="hi" ) -%}
+"#,
+    ext = "html"
+)]
+struct TrailingComma;
+
+#[test]
+fn test_trailing_comma() {
+    assert_eq!(TrailingComma.render().unwrap(), "hihihihihi");
+}


### PR DESCRIPTION
Quite convenient when arguments are on different lines.

(First commit comes from https://github.com/djc/askama/pull/925, it will prevent to have a merge conflict once the first one will be merged)