### PR TITLE
Add `{% call ... %}{% endcall %}` and `caller()` inside macros

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -830,7 +830,7 @@ impl<'a> Generator<'a> {
 
     fn handle_include(
         &mut self,
-        ctx: &Context<'_>,
+        ctx: &Context<'a>,
         buf: &mut Buffer,
         i: &'a Include<'_>,
     ) -> Result<usize, CompileError> {

--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -35,6 +35,7 @@ impl Heritage<'_> {
 
 type BlockAncestry<'a> = HashMap<&'a str, Vec<(&'a Context<'a>, &'a BlockDef<'a>)>>;
 
+#[derive(Clone)]
 pub(crate) struct Context<'a> {
     pub(crate) nodes: &'a [Node<'a>],
     pub(crate) extends: Option<PathBuf>,

--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -596,11 +596,11 @@ impl<'a> Call<'a> {
                 opt(terminated(ws(identifier), ws(tag("::")))),
                 ws(identifier),
                 opt(ws(|nested| Expr::arguments(nested, s.level.get(), true))),
-                opt(Whitespace::parse),
                 opt(ws(tag("with"))),
+                opt(Whitespace::parse),
             ))),
         ));
-        let (i, (pws1, _, (caller_params, scope, name, args, nws1, with))) = p(i)?;
+        let (i, (pws1, _, (caller_params, scope, name, args, with, nws1))) = p(i)?;
         let args = args.unwrap_or_default();
         let (i, caller) = if caller_params.is_some() || with.is_some() {
             let mut end = cut(pair(

--- a/testing/templates/caller-macro.html
+++ b/testing/templates/caller-macro.html
@@ -1,0 +1,7 @@
+{%- macro m(x) -%}
+    begin {{ x }}: {% call caller(5) %} [end {{ x }}].
+{%- endmacro -%}
+
+{%- call(b) m(a) with -%}
+    {{ a + x + b }}
+{%- endcall -%}

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -170,3 +170,15 @@ struct TrailingComma;
 fn test_trailing_comma() {
     assert_eq!(TrailingComma.render().unwrap(), "hihihihihi");
 }
+
+#[derive(Template)]
+#[template(path = "caller-macro.html")]
+struct CallerMacro {
+    a: u32,
+}
+
+#[test]
+fn test_macro_caller() {
+    let t = CallerMacro { a: 8 };
+    assert_eq!(t.render().unwrap(), "begin 8: 21 [end 8].")
+}


### PR DESCRIPTION
When a `{% call ... %}` block either has parameters right after `call`, or when the call block ends with the keyword `with`, the `call` is going to create a caller macro and expect an `{% endcall %}` block.

For example:
```jinja
{% macro m(class) %}
    <div class="{{ class }}">
        {% call caller("<div>") %}
    </div>
{% endmacro %}
{% call(el) m("box") with %}
    I'm inside {{ el }}.
{% endcall %}
```