### PR TITLE
Revert "Add automatic borrowing to `let` statements"

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -916,14 +916,7 @@ impl<'a> Generator<'a> {
         };
 
         let mut expr_buf = Buffer::new(0);
-        let borrow_val = !is_copyable(val);
-        if borrow_val {
-            expr_buf.write("&(");
-        }
         self.visit_expr(&mut expr_buf, val)?;
-        if borrow_val {
-            expr_buf.write(")");
-        }
 
         let shadowed = self.is_shadowing_variable(&l.var)?;
         if shadowed {

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -484,17 +484,3 @@ fn test_num_literals() {
         "[90, -90, 90, 2, 56, 240, 10.5, 10.5, 100000000000, 105000000000]",
     );
 }
-
-#[derive(askama::Template)]
-#[template(source = "{% let word = s %}{{ word }}", ext = "html")]
-struct LetBorrow {
-    s: String,
-}
-
-#[test]
-fn test_let_borrow() {
-    let template = LetBorrow {
-        s: "hello".to_owned(),
-    };
-    assert_eq!(template.render().unwrap(), "hello")
-}


### PR DESCRIPTION
Reverts djc/askama#922

As discussed in https://github.com/djc/askama/pull/937, this was actually a pretty bad idea to do this. We'll need to discuss about potential ways to go around this limit but in the meantime, better revert it.

@PizzasBear: Can't you write a filter `as_ref` which takes a ref and returns a ref in the meantime to go around the limitation in your case?