### PR TITLE
Make `String` compatible with the markdown filter.

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -1200,7 +1200,7 @@ impl<'a> Generator<'a> {
         };
 
         buf.write(&format!(
-            "::askama::filters::markdown({}, ",
+            "::askama::filters::markdown({}, &",
             self.input.escaper
         ));
         self.visit_expr(buf, md)?;

--- a/testing/tests/markdown.rs
+++ b/testing/tests/markdown.rs
@@ -70,3 +70,21 @@ before\
 after",
     );
 }
+
+#[derive(Template)]
+#[template(source = "{{content|markdown}}", ext = "html")]
+struct MarkdownStringTemplate {
+    content: String,
+}
+
+// Tests if the markdown filter accepts String
+#[test]
+fn test_markdown_owned_string() {
+    let template = MarkdownStringTemplate {
+        content: "The markdown filter _indeed_ works with __String__".into(),
+    };
+    assert_eq!(
+        template.render().unwrap(),
+        "<p>The markdown filter <em>indeed</em> works with <strong>String</strong></p>\n"
+    )
+}


### PR DESCRIPTION
Hello, I recently decided to switch from Tera to Askama, and I'm enjoying it so far. 

Yesterday, I stumbled upon issue #719 and decided to see if I can fix the issue with the markdown filter, so I don't have to include Comrak in my own crate as a workaround. 
What I found out is that the issue with using `String` is that the filter moves the value out of the struct. This is fine for `&str` considering `&str` is already a reference. 
```rs
    /// Code generated by Template derive macro  
    fn render_into(&self, writer: &mut (impl ::std::fmt::Write + ?Sized)) -> ::askama::Result<()> {
    ...
            expr0 = &::askama::filters::markdown(::askama::Html, self.content, ::core::option::Option::None)?,
            //                                                   ^^^^^^^^^^^^ 
            //                                              Value gets moved out by filter 
    ...
```

Making the generated code borrow the value did not create any problems in tests.

This PR also adds a test for passing `String`s to the markdown filter and simplifies the function
signature for the filter to accept `&str`. 
