### PR TITLE
parser: add missing license files

### DIFF
--- a/askama_parser/LICENSE-APACHE
+++ b/askama_parser/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/askama_parser/LICENSE-MIT
+++ b/askama_parser/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
It looks like adding the symlinks to the license files was missed when askama_parser crate was added, since all other crates in this project have them.

If possible, it would be great if you could release a new version of askama_parser that contains the license texts. I'm currently working on updating the packages for the askama* crates in Fedora Linux, and I'm currently blocked on published versions of askama_parser not containing the required license texts.