### PR TITLE
Fix support for mixed case variables

### DIFF
--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -349,9 +349,9 @@ fn path_or_identifier(i: &str) -> ParseResult<'_, PathOrIdentifier<'_>> {
     let rest = rest.as_deref().unwrap_or_default();
 
     // The returned identifier can be assumed to be path if:
-    // - Contains both a lowercase and uppercase character, i.e. a type name like `None`
-    // - Doesn't contain any lowercase characters, i.e. it's a constant
-    // In short, if it contains any uppercase characters it's a path.
+    // - it is an absolute path (starts with `::`), or
+    // - it has multiple components (at least one `::`), or
+    // - the first letter is uppercase
     match (root, start, rest) {
         (Some(_), start, tail) => {
             let mut path = Vec::with_capacity(2 + tail.len());
@@ -360,7 +360,7 @@ fn path_or_identifier(i: &str) -> ParseResult<'_, PathOrIdentifier<'_>> {
             path.extend(rest);
             Ok((i, PathOrIdentifier::Path(path)))
         }
-        (None, name, []) if !name.contains(char::is_uppercase) => {
+        (None, name, []) if name.chars().next().map_or(true, |c| c.is_lowercase()) => {
             Ok((i, PathOrIdentifier::Identifier(name)))
         }
         (None, start, tail) => {

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -484,3 +484,23 @@ fn test_num_literals() {
         "[90, -90, 90, 2, 56, 240, 10.5, 10.5, 100000000000, 105000000000]",
     );
 }
+
+#[allow(non_snake_case)]
+#[derive(askama::Template)]
+#[template(source = "{{ xY }}", ext = "txt")]
+struct MixedCase {
+    xY: &'static str,
+}
+
+/// Test that we can use mixed case in variable names
+///
+/// We use some heuristics to distinguish paths (`std::str::String`) from
+/// variable names (`foo`). Previously, this test would fail because any
+/// name containing uppercase characters would be considered a path.
+///
+/// https://github.com/djc/askama/issues/924
+#[test]
+fn test_mixed_case() {
+    let template = MixedCase { xY: "foo" };
+    assert_eq!(template.render().unwrap(), "foo");
+}


### PR DESCRIPTION
Fixes #924. Looks like this might have regressed in #840. I think checking only the first letter is a better heuristic than checking if any letters are uppercase.