### PR TITLE
Remove `syn` and `proc-macro2` and `quote` dependencies from `askama_derive`

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -34,6 +34,5 @@ with-warp = []
 parser = { package = "askama_parser", version = "0.2", path = "../askama_parser" }
 mime = "0.3"
 mime_guess = "2"
-quote = "1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 basic-toml = { version = "0.1.1", optional = true }

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -34,8 +34,6 @@ with-warp = []
 parser = { package = "askama_parser", version = "0.2", path = "../askama_parser" }
 mime = "0.3"
 mime_guess = "2"
-proc-macro2 = "1"
 quote = "1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-syn = "2"
 basic-toml = { version = "0.1.1", optional = true }

--- a/askama_derive/src/parse_proc_macro.rs
+++ b/askama_derive/src/parse_proc_macro.rs
@@ -1,0 +1,289 @@
+use proc_macro::token_stream::IntoIter as ProcIter;
+use proc_macro::{Delimiter, TokenTree};
+
+use std::fmt;
+
+#[derive(Clone, Default, Debug)]
+pub(crate) struct Generics {
+    inner: Vec<(String, Option<String>)>,
+}
+
+impl Generics {
+    pub(crate) fn add_lifetime(&mut self, lifetime: &str, bounds: &str) {
+        let lifetime = lifetime.trim();
+        if lifetime.is_empty() {
+            return;
+        }
+        let bounds = bounds.trim();
+        if bounds.is_empty() {
+            self.inner.insert(0, (lifetime.to_string(), None));
+        } else {
+            self.inner
+                .insert(0, (lifetime.to_string(), Some(bounds.to_string())));
+        }
+    }
+
+    pub(crate) fn add_generic(&mut self, bound_name: &str, bounds: &str) {
+        let bound_name = bound_name.trim();
+        let bounds = bounds.trim();
+
+        if bound_name.is_empty() {
+            // Nothing to do...
+        } else if bounds.is_empty() {
+            self.inner.push((bound_name.to_string(), None));
+        } else {
+            self.inner
+                .push((bound_name.to_string(), Some(bounds.to_string())));
+        }
+    }
+
+    pub(crate) fn display_with_bounds(&self) -> String {
+        if self.inner.is_empty() {
+            return String::new();
+        }
+        format!(
+            "<{}>",
+            self.inner
+                .iter()
+                .map(|(generic, bounds)| {
+                    if let Some(bounds) = bounds {
+                        format!("{generic}: {bounds}")
+                    } else {
+                        generic.clone()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    }
+}
+
+impl fmt::Display for Generics {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.inner.is_empty() {
+            return Ok(());
+        }
+        write!(
+            f,
+            "<{}>",
+            self.inner
+                .iter()
+                .filter(|(generic, _)| generic != "'_")
+                .map(
+                    |(generic, _)| if let Some(stripped) = generic.strip_prefix("const ") {
+                        stripped
+                    } else {
+                        generic.as_str()
+                    }
+                )
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub(crate) struct WhereClause {
+    inner: Option<String>,
+}
+
+#[cfg(feature = "with-mendes")]
+impl WhereClause {
+    pub(crate) fn add_predicate(&mut self, predicate: &str) {
+        let predicate = predicate.trim();
+
+        if predicate.is_empty() {
+            return;
+        }
+        if let Some(inner) = self.inner.as_mut() {
+            if !inner.ends_with(',') {
+                inner.push(',');
+            }
+            inner.push_str(predicate);
+        } else {
+            self.inner = Some(predicate.to_string());
+        }
+    }
+}
+
+impl fmt::Display for WhereClause {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.inner {
+            Some(ref inner) => write!(f, "where {inner}"),
+            None => Ok(()),
+        }
+    }
+}
+
+fn skip_until_back_to_first_level(
+    iter: &mut ProcIter,
+    mut tokens_with_bounds: Option<&mut String>,
+) {
+    let mut level = 1;
+
+    for token in iter {
+        if let Some(tokens) = tokens_with_bounds.as_mut() {
+            tokens.push_str(&token.to_string());
+        }
+        if let TokenTree::Punct(ref p) = token {
+            match p.as_char() {
+                '>' => {
+                    level -= 1;
+                    if level < 1 {
+                        return;
+                    }
+                }
+                '<' => level += 1,
+                _ => {}
+            }
+        }
+    }
+}
+
+fn skip_until_next_generic(iter: &mut ProcIter) -> bool {
+    while let Some(token) = iter.next() {
+        if let TokenTree::Punct(ref p) = token {
+            match p.as_char() {
+                ',' => return true,
+                '>' => return false,
+                '<' => skip_until_back_to_first_level(iter, None),
+                _ => {}
+            }
+        }
+    }
+    false
+}
+
+fn only_bounds(iter: &mut ProcIter, tokens_with_bounds: &mut String) -> bool {
+    while let Some(token) = iter.next() {
+        if let TokenTree::Punct(ref p) = token {
+            match p.as_char() {
+                '>' => return false,
+                '<' => skip_until_back_to_first_level(iter, Some(tokens_with_bounds)),
+                ',' => return true,
+                '=' => return skip_until_next_generic(iter),
+                _ => {}
+            }
+        }
+        tokens_with_bounds.push_str(&token.to_string());
+    }
+    false
+}
+
+/// Parses and retrieves type's ident, generics (if any) and where clauses (if any).
+pub(crate) fn get_generics_and_type_name(
+    iter: &mut ProcIter,
+    ident: &mut Option<String>,
+    generics: &mut Generics,
+    where_clause: &mut WhereClause,
+) {
+    match iter.next() {
+        Some(TokenTree::Ident(id)) => *ident = Some(id.to_string()),
+        _ => return,
+    }
+    match iter.next() {
+        Some(TokenTree::Punct(p)) if p.as_char() == '<' => {
+            let mut generic = String::new();
+
+            while let Some(token) = iter.next() {
+                let should_continue = match token {
+                    TokenTree::Punct(ref p) => {
+                        match p.as_char() {
+                            '>' => {
+                                generics.add_generic(&generic, "");
+                                break;
+                            }
+                            '=' => {
+                                generics.add_generic(&generic, "");
+                                generic.clear();
+                                skip_until_next_generic(iter)
+                            }
+                            ':' => {
+                                if let Some(new_token) = iter.next() {
+                                    if matches!(new_token, TokenTree::Punct(ref p) if p.as_char() == ':')
+                                    {
+                                        // It's a path.
+                                        generic.push_str("::");
+                                    // It's generic bounds.
+                                    } else {
+                                        let mut bounds = new_token.to_string();
+                                        let ret = only_bounds(iter, &mut bounds);
+                                        generics.add_generic(&generic, &bounds);
+                                        generic.clear();
+                                        if !ret {
+                                            break;
+                                        }
+                                    }
+                                    continue;
+                                } else {
+                                    break;
+                                }
+                            }
+                            ',' => {
+                                generics.add_generic(&generic, "");
+                                generic.clear();
+                                continue;
+                            }
+                            _ => true,
+                        }
+                    }
+                    _ => true,
+                };
+                generic.push_str(&token.to_string());
+                if !should_continue {
+                    break;
+                }
+                if matches!(token, TokenTree::Ident(_)) {
+                    generic.push(' ');
+                }
+            }
+        }
+        _ => return,
+    }
+    match iter.next() {
+        Some(TokenTree::Ident(id)) if id.to_string() == "where" => {}
+        _ => return,
+    }
+    let mut tokens = String::new();
+    let mut bracket_group_level = 0;
+    while let Some(token) = iter.next() {
+        match token {
+            TokenTree::Punct(ref p) => {
+                // As long as we're inside this, we need to ignore bracket groups to handle
+                // cases like:
+                //
+                // ```
+                // trait Bar<const X: usize>{}
+                // struct Foo<F> where F: Bar<{12}> { inner: F }
+                // ```
+                match p.as_char() {
+                    '<' => bracket_group_level += 1,
+                    '>' => bracket_group_level -= 1,
+                    ':' if bracket_group_level == 0 => {
+                        if let Some(token) = iter.next() {
+                            if matches!(token, TokenTree::Punct(ref p) if p.as_char() == ':') {
+                                // it's a path
+                                tokens.push_str("::");
+                            } else {
+                                tokens.push_str(": ");
+                                tokens.push_str(&token.to_string());
+                            }
+                            continue;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            TokenTree::Group(ref g)
+                if bracket_group_level == 0 && g.delimiter() != Delimiter::None =>
+            {
+                break
+            }
+            _ => {}
+        }
+        tokens.push_str(&token.to_string());
+    }
+    where_clause.inner = Some(tokens);
+}

--- a/askama_derive/src/unescape.rs
+++ b/askama_derive/src/unescape.rs
@@ -1,0 +1,158 @@
+// This code is a simplified version of the `rustc_lexer` unescape.
+
+use crate::CompileError;
+use proc_macro::Literal;
+use std::str::Chars;
+
+fn scan_unicode(chars: &mut Chars<'_>) -> Result<char, CompileError> {
+    // We've parsed '\u', now we have to parse '{..}'.
+
+    if chars.next() != Some('{') {
+        return Err("expected { after \\u".into());
+    }
+
+    // First character must be a hexadecimal digit.
+    let mut value: u32 = match chars
+        .next()
+        .ok_or_else(|| CompileError::from("unclosed `\\u`"))?
+    {
+        '}' => return Err("invalid empty unicode escape `\\u{}`".into()),
+        c => c.to_digit(16).ok_or_else(|| {
+            CompileError::from(format!("unexpected non hex character after \\u: `{c}`"))
+        })?,
+    };
+    let mut n_digits = 1;
+
+    // First character is valid, now parse the rest of the number
+    // and closing brace.
+    loop {
+        match chars.next() {
+            None => return Err("unclosed unicode escape".into()),
+            Some('_') => continue,
+            Some('}') => {
+                break std::char::from_u32(value).ok_or_else(|| {
+                    CompileError::from(format!(
+                        "character code {value:x} is not a valid unicode character"
+                    ))
+                });
+            }
+            Some(c) => {
+                n_digits += 1;
+                let digit: u32 = c.to_digit(16).ok_or_else(|| {
+                    CompileError::from(format!("unexpected non hex character after `\\u`: `{c}`"))
+                })?;
+                if n_digits > 6 {
+                    return Err("overlong unicode escape (must have at most 6 hex digits)".into());
+                }
+                value = value * 16 + digit;
+            }
+        };
+    }
+}
+
+fn scan_escape(chars: &mut Chars<'_>) -> Result<char, CompileError> {
+    // Previous character was '\\', unescape what follows.
+    let res = match chars.next().ok_or("expected a character after `\\`")? {
+        '"' => b'"',
+        'n' => b'\n',
+        'r' => b'\r',
+        't' => b'\t',
+        '\\' => b'\\',
+        '\'' => b'\'',
+        '0' => b'\0',
+
+        'x' => {
+            // Parse hexadecimal character code.
+
+            let hi = chars
+                .next()
+                .ok_or_else(|| CompileError::from("too short \\x escape"))?;
+            let hi = hi
+                .to_digit(16)
+                .ok_or_else(|| CompileError::from("unexpected non-hex character after \\x"))?;
+
+            let lo = chars
+                .next()
+                .ok_or_else(|| CompileError::from("too short \\x escape"))?;
+            let lo = lo
+                .to_digit(16)
+                .ok_or_else(|| CompileError::from("unexpected non-hex character after \\x"))?;
+
+            let value = hi * 16 + lo;
+
+            value as u8
+        }
+
+        'u' => return scan_unicode(chars).map(Into::into),
+        c => return Err(format!("unknown espace `\\{c}`").into()),
+    };
+    Ok(res.into())
+}
+
+fn skip_ascii_whitespace(chars: &mut Chars<'_>) {
+    let tail = chars.as_str();
+    let first_non_space = tail
+        .bytes()
+        .position(|b| b != b' ' && b != b'\t' && b != b'\n' && b != b'\r')
+        .unwrap_or(tail.len());
+    let tail = &tail[first_non_space..];
+    *chars = tail.chars();
+}
+
+fn get_str(src: &str) -> Result<String, CompileError> {
+    let mut chars = src.chars();
+    let mut output = String::with_capacity(src.len());
+
+    while let Some(c) = chars.next() {
+        let res = match c {
+            '\\' => {
+                match chars.clone().next() {
+                    Some('\n') => {
+                        // Rust language specification requires us to skip whitespaces
+                        // if unescaped '\' character is followed by '\n'.
+                        // For details see [Rust language reference]
+                        // (https://doc.rust-lang.org/reference/tokens.html#string-literals).
+                        skip_ascii_whitespace(&mut chars);
+                        continue;
+                    }
+                    _ => scan_escape(&mut chars)?,
+                }
+            }
+            '"' => return Err("unexpected `\"` character".into()),
+            '\r' => return Err("unexpected `\r` character".into()),
+            c => c,
+        };
+        output.push(res);
+    }
+    Ok(output)
+}
+
+pub(crate) fn get_str_literal(lit: Literal, ident: &str) -> Result<String, CompileError> {
+    let lit = lit.to_string();
+
+    match lit.bytes().next() {
+        Some(b'"') => get_str(&lit[1..lit.len() - 1]),
+        Some(b'r') => {
+            let mut bytes = lit[1..].bytes();
+            let mut pounds = 0;
+            while let Some(b'#') = bytes.next() {
+                pounds += 1;
+            }
+            let lit = &lit[pounds + 1..];
+            if lit.bytes().next() != Some(b'"') {
+                return Err(
+                    format!("template `{ident}` must be a string literal, found `{lit}`").into(),
+                );
+            }
+            // If the string wasn't closed, we wouldn't be here in the first place...
+            let close = lit.rfind('"').unwrap();
+            if !lit[close + 1..].bytes().all(|c| c == b'#') || lit[close + 1..].len() != pounds {
+                return Err(
+                    format!("template `{ident}` must be a string literal, found `{lit}`").into(),
+                );
+            }
+            Ok(lit[1..close].to_string())
+        }
+        _ => Err(format!("template `{ident}` must be a string literal").into()),
+    }
+}


### PR DESCRIPTION
So overall, I think it'll be much more efficient to parse the derive proc-macro (not sure exactly how to test it...) as this code doesn't try to make sense of most tokens it parses.

However, and I think it's quite important to note: it has a maintenance cost (as does any code) and if you don't think it's worth it, we can close it. The proc-macro performance isn't that critical and the three dependencies are still in the dependency tree since `askama` uses `serde`.

Even if not merged, some improvements in the code can still be retrieved from this code, mostly around how the code is generated. I think that splitting code generation into a lot of small calls to `writeln` makes it much more difficult to have an idea of what the generated code will look like.

Anyway, it was fun to do. Parsing rustc tokens is pretty easy so I did it originally to see how hard it would be to not use `syn` and all the crates (which are great, but because they need to support a lot of cases, are bound to be slower than hand-made code, specific to one use case).