### PR TITLE
Improve error when whitespace control is used on extends

### DIFF
--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -928,8 +928,22 @@ pub struct Extends<'a> {
 
 impl<'a> Extends<'a> {
     fn parse(i: &'a str) -> ParseResult<'a, Self> {
-        let (i, path) = preceded(ws(keyword("extends")), cut(ws(str_lit)))(i)?;
-        Ok((i, Self { path }))
+        let start = i;
+
+        let (i, (pws, _, (path, nws))) = tuple((
+            opt(Whitespace::parse),
+            ws(keyword("extends")),
+            cut(pair(ws(str_lit), opt(Whitespace::parse))),
+        ))(i)?;
+        match (pws, nws) {
+            (None, None) => Ok((i, Self { path })),
+            (_, _) => Err(nom::Err::Failure(ErrorContext {
+                input: start,
+                message: Some(Cow::Borrowed(
+                    "whitespace control is not allowed on `extends`",
+                )),
+            })),
+        }
     }
 }
 

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -328,6 +328,16 @@ blocks from the base template with those from the child template. Inside
 a block in a child template, the `super()` macro can be called to render
 the parent block's contents.
 
+Because top-level content from the child template is thus ignored, the `extends`
+tag doesn't support whitespace control:
+
+```html
+{%- extends "base.html" +%}
+```
+
+The above code is rejected because we used `-` and `+`. For more information
+about whitespace control, take a look [here](#whitespace-control).
+
 ## HTML escaping
 
 Askama by default escapes variables if it thinks it is rendering HTML

--- a/testing/tests/ui/extends.rs
+++ b/testing/tests/ui/extends.rs
@@ -1,0 +1,18 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(
+    source = r#"{%- extends "whatever.html" %}"#,
+    ext = "html"
+)]
+struct ExtendsPre;
+
+#[derive(Template)]
+#[template(
+    source = r#"{% extends "whatever.html" -%}"#,
+    ext = "html"
+)]
+struct ExtendsPost;
+
+fn main() {
+}

--- a/testing/tests/ui/extends.stderr
+++ b/testing/tests/ui/extends.stderr
@@ -1,0 +1,19 @@
+error: whitespace control is not allowed on `extends`
+       problems parsing template source at row 1, column 2 near:
+       "- extends \"whatever.html\" %}"
+ --> tests/ui/extends.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: whitespace control is not allowed on `extends`
+       problems parsing template source at row 1, column 2 near:
+       " extends \"whatever.html\" -%}"
+  --> tests/ui/extends.rs:10:10
+   |
+10 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Took me a while to understand why `askama` was complaining about an `extends`. Realized that it was because whitespace control is not allowed on it. Even though it does nothing, I think it's not great user experience to that this opaque error with valid jinja code so I updated the parser to allow it.