### PR TITLE
Auto-add integration prefix in derive

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama"
-version = "0.12.1"
+version = "0.13.0"
 description = "Type-safe, compiled Jinja-like templates for Rust"
 documentation = "https://docs.rs/askama"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -39,7 +39,7 @@ mime = []
 mime_guess = []
 
 [dependencies]
-askama_derive = { version = "0.12.0", path = "../askama_derive" }
+askama_derive = { version = "0.13", path = "../askama_derive" }
 askama_escape = { version = "0.10.3", path = "../askama_escape" }
 comrak = { version = "0.21", optional = true, default-features = false }
 dep_humansize = { package = "humansize", version = "2", optional = true }

--- a/askama_actix/Cargo.toml
+++ b/askama_actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_actix"
-version = "0.14.0"
+version = "0.15.0"
 description = "Actix-Web integration for Askama templates"
 documentation = "https://docs.rs/askama"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -15,7 +15,7 @@ rust-version = "1.65"
 
 [dependencies]
 actix-web = { version = "4", default-features = false }
-askama = { version = "0.12", path = "../askama", default-features = false, features = ["with-actix-web"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-actix-web"] }
 
 [dev-dependencies]
 actix-rt = { version = "2", default-features = false }

--- a/askama_axum/Cargo.toml
+++ b/askama_axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_axum"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.65"
 description = "Axum integration for Askama templates"
@@ -14,7 +14,7 @@ workspace = ".."
 readme = "README.md"
 
 [dependencies]
-askama = { version = "0.12", path = "../askama", default-features = false, features = ["with-axum", "mime", "mime_guess"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-axum", "mime", "mime_guess"] }
 axum-core = "0.4"
 http = "1.0"
 

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_derive"
-version = "0.12.5"
+version = "0.13.0"
 description = "Procedural macro package for Askama"
 homepage = "https://github.com/djc/askama"
 repository = "https://github.com/djc/askama"

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -5,7 +5,7 @@ use std::{env, fs};
 #[cfg(feature = "serde")]
 use serde::Deserialize;
 
-use crate::CompileError;
+use crate::{CompileError, CRATE};
 use parser::node::Whitespace;
 use parser::Syntax;
 
@@ -93,7 +93,7 @@ impl<'a> Config<'a> {
             }
         }
         for (extensions, path) in DEFAULT_ESCAPERS {
-            escapers.push((str_set(extensions), (*path).to_string()));
+            escapers.push((str_set(extensions), format!("{CRATE}{path}")));
         }
 
         Ok(Config {
@@ -299,9 +299,9 @@ pub(crate) fn get_template_source(tpl_path: &Path) -> std::result::Result<String
 static CONFIG_FILE_NAME: &str = "askama.toml";
 static DEFAULT_SYNTAX_NAME: &str = "default";
 static DEFAULT_ESCAPERS: &[(&[&str], &str)] = &[
-    (&["html", "htm", "svg", "xml"], "::askama::Html"),
-    (&["md", "none", "txt", "yml", ""], "::askama::Text"),
-    (&["j2", "jinja", "jinja2"], "::askama::Html"),
+    (&["html", "htm", "svg", "xml"], "::Html"),
+    (&["md", "none", "txt", "yml", ""], "::Text"),
+    (&["j2", "jinja", "jinja2"], "::Html"),
 ];
 
 #[cfg(test)]

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -156,3 +156,23 @@ const BUILT_IN_FILTERS: &[&str] = &[
     "markdown",
     "yaml",
 ];
+
+const CRATE: &str = if cfg!(feature = "with-actix-web") {
+    "::askama_actix"
+} else if cfg!(feature = "with-axum") {
+    "::askama_axum"
+} else if cfg!(feature = "with-gotham") {
+    "::askama_gotham"
+} else if cfg!(feature = "with-hyper") {
+    "::askama_hyper"
+} else if cfg!(feature = "with-mendes") {
+    "::askama_mendes"
+} else if cfg!(feature = "with-rocket") {
+    "::askama_rocket"
+} else if cfg!(feature = "with-tide") {
+    "::askama_tide"
+} else if cfg!(feature = "with-warp") {
+    "::askama_warp"
+} else {
+    "::askama"
+};

--- a/askama_gotham/Cargo.toml
+++ b/askama_gotham/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_gotham"
-version = "0.14.0"
+version = "0.15.0"
 description = "Gotham integration for Askama templates"
 documentation = "https://docs.rs/askama"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-askama = { version = "0.12", path = "../askama", default-features = false, features = ["with-gotham", "mime", "mime_guess"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-gotham", "mime", "mime_guess"] }
 gotham = { version = "0.7", default-features = false }
 
 [dev-dependencies]

--- a/askama_hyper/Cargo.toml
+++ b/askama_hyper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_hyper"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hyper integration for Askama templates"
 documentation = "https://docs.rs/askama"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-askama = { version = "0.12", path = "../askama", default-features = false, features = ["with-hyper"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-hyper"] }
 hyper = { version = "0.14", default-features = false }
 
 [dev-dependencies]

--- a/askama_mendes/Cargo.toml
+++ b/askama_mendes/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-askama = { version = "0.12", path = "../askama", default-features = false, features = ["with-mendes", "mime", "mime_guess"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-mendes", "mime", "mime_guess"] }
 mendes = "0.5.0"
 
 [dev-dependencies]

--- a/askama_rocket/Cargo.toml
+++ b/askama_rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_rocket"
-version = "0.12.0"
+version = "0.13.0"
 description = "Rocket integration for Askama templates"
 documentation = "https://docs.rs/askama"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -14,8 +14,8 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-askama = { version = "0.12", path = "../askama", default-features = false, features = ["with-rocket", "mime", "mime_guess"] }
-rocket = { version = "0.5.0", default-features = false }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-rocket", "mime", "mime_guess"] }
+rocket = { version = "0.5", default-features = false }
 
 [dev-dependencies]
 futures-lite = "2.0.0"

--- a/askama_rocket/src/lib.rs
+++ b/askama_rocket/src/lib.rs
@@ -8,9 +8,9 @@ pub use askama::*;
 use rocket::http::{Header, Status};
 pub use rocket::request::Request;
 use rocket::response::Response;
-pub use rocket::response::{Responder, Result};
+pub use rocket::response::{Responder, Result as RocketResult};
 
-pub fn respond<T: Template>(t: &T) -> Result<'static> {
+pub fn respond<T: Template>(t: &T) -> RocketResult<'static> {
     let rsp = t.render().map_err(|_| Status::InternalServerError)?;
     Response::build()
         .header(Header::new("content-type", T::MIME_TYPE))

--- a/askama_tide/Cargo.toml
+++ b/askama_tide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_tide"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.65"
 description = "Tide integration for Askama templates"
@@ -13,7 +13,7 @@ workspace = ".."
 readme = "README.md"
 
 [dependencies]
-askama = { version = "0.12", path = "../askama", default-features = false, features = ["with-tide"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-tide"] }
 tide = { version = "0.16", default-features = false }
 
 [dev-dependencies]

--- a/askama_tide/src/lib.rs
+++ b/askama_tide/src/lib.rs
@@ -2,7 +2,6 @@
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 
-pub use askama;
 pub use tide;
 
 pub use askama::*;

--- a/askama_warp/Cargo.toml
+++ b/askama_warp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_warp"
-version = "0.13.0"
+version = "0.14.0"
 description = "Warp integration for Askama templates"
 documentation = "https://docs.rs/askama"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-askama = { version = "0.12", path = "../askama", default-features = false, features = ["with-warp", "mime", "mime_guess"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-warp", "mime", "mime_guess"] }
 warp = { version = "0.3", default-features = false }
 
 [dev-dependencies]

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -4,8 +4,7 @@ First, add the following to your crate's `Cargo.toml`:
 
 ```toml
 # in section [dependencies]
-askama = "0.11.2"
-
+askama = "0.12.1"
 ```
 
 Now create a directory called `templates` in your crate root.
@@ -35,3 +34,25 @@ fn main() {
 ```
 
 You should now be able to compile and run this code.
+
+## Using integrations
+
+To use one of the [integrations](./integrations.md), with axum as an example:
+
+First, add this to your `Cargo.toml` instead:
+
+```toml
+# in section [dependencies]
+askama_axum = "0.4.0"
+```
+
+Then, import from askama_axum instead of askama:
+
+```rust
+use askama_axum::Template;
+```
+
+This enables the implementation for axum's `IntoResponse` trait,
+so an instance of the template can be returned as a response.
+
+For other integrations, import and use their crate accordingly.

--- a/book/src/integrations.md
+++ b/book/src/integrations.md
@@ -2,6 +2,9 @@
 
 ## Rocket integration
 
+In your template definitions, replace `askama::Template` with
+[`askama_rocket::Template`][askama_rocket].
+
 Enabling the `with-rocket` feature appends an implementation of Rocket's
 `Responder` trait for each template type. This makes it easy to trivially
 return a value of that type in a Rocket handler. See
@@ -14,6 +17,9 @@ handled by your error catcher.
 
 ## Actix-web integration
 
+In your template definitions, replace `askama::Template` with
+[`askama_actix::Template`][askama_actix].
+
 Enabling the `with-actix-web` feature appends an implementation of Actix-web's
 `Responder` trait for each template type. This makes it easy to trivially return
 a value of that type in an Actix-web handler. See
@@ -21,6 +27,9 @@ a value of that type in an Actix-web handler. See
 from the Askama test suite for more on how to integrate.
 
 ## Axum integration
+
+In your template definitions, replace `askama::Template` with
+[`askama_axum::Template`][askama_axum].
 
 Enabling the `with-axum` feature appends an implementation of Axum's
 `IntoResponse` trait for each template type. This makes it easy to trivially
@@ -34,6 +43,9 @@ This preserves the response chain if any custom error handling needs to occur.
 
 ## Gotham integration
 
+In your template definitions, replace `askama::Template` with
+[`askama_gotham::Template`][askama_gotham].
+
 Enabling the `with-gotham` feature appends an implementation of Gotham's
 `IntoResponse` trait for each template type. This makes it easy to trivially
 return a value of that type in a Gotham handler. See
@@ -46,6 +58,9 @@ This preserves the response chain if any custom error handling needs to occur.
 
 ## Warp integration
 
+In your template definitions, replace `askama::Template` with
+[`askama_warp::Template`][askama_warp].
+
 Enabling the `with-warp` feature appends an implementation of Warp's `Reply`
 trait for each template type. This makes it simple to return a template from
 a Warp filter. See [the example](https://github.com/djc/askama/blob/main/askama_warp/tests/warp.rs)
@@ -53,9 +68,19 @@ from the Askama test suite for more on how to integrate.
 
 ## Tide integration
 
+In your template definitions, replace `askama::Template` with
+[`askama_tide::Template`][askama_tide].
+
 Enabling the `with-tide` feature appends `Into<tide::Response>` and
 `TryInto<tide::Body>` implementations for each template type. This
 provides the ability for tide apps to build a response directly from
 a template, or to append a templated body to an existing
 `Response`. See [the example](https://github.com/djc/askama/blob/main/askama_tide/tests/tide.rs)
 from the Askama test suite for more on how to integrate.
+
+[askama_rocket]: https://docs.rs/askama_rocket
+[askama_actix]: https://docs.rs/askama_actix
+[askama_axum]: https://docs.rs/askama_axum
+[askama_gotham]: https://docs.rs/askama_gotham
+[askama_warp]: https://docs.rs/askama_warp
+[askama_tide]: https://docs.rs/askama_tide

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -13,7 +13,7 @@ serde-json = ["serde_json", "askama/serde-json"]
 markdown = ["comrak", "askama/markdown"]
 
 [dependencies]
-askama = { path = "../askama", version = "0.12" }
+askama = { path = "../askama", version = "0.13" }
 comrak = { version = "0.21", default-features = false, optional = true }
 phf = { version = "0.11", features = ["macros" ]}
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
… to avoid need for importing askama itself. Closes #962.

Performance is negligible in a `cargo bench` comparison (criterion reports either in error margin or no performance change detected). If you think it's still too much, the branch can be easily moved to a separate `fn`.

Update: as suggested, also closes #961.