### PR TITLE
Remove deprecated deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [licenses]
-allow-osi-fsf-free = "either"
-copyleft = "warn"
-exceptions = [{ allow = ["ISC", "MIT", "OpenSSL"], name = "ring" }]
+version = 2
+allow = ["Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MIT", "Unicode-DFS-2016"]
 private = { ignore = true }
 
 [[licenses.clarify]]


### PR DESCRIPTION
```
warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /Users/djc/src/askama/deny.toml:2:1
  │
2 │ allow-osi-fsf-free = "either"
  │ ^^^^^^^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /Users/djc/src/askama/deny.toml:3:1
  │
3 │ copyleft = "warn"
```