### PR TITLE
Remove unused `Next` variant value

### DIFF
--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -201,16 +201,16 @@ fn skip_till<'a, O>(
 ) -> impl FnMut(&'a str) -> ParseResult<'a, (&'a str, O)> {
     enum Next<O> {
         IsEnd(O),
-        NotEnd(char),
+        NotEnd,
     }
-    let mut next = alt((map(end, Next::IsEnd), map(anychar, Next::NotEnd)));
+    let mut next = alt((map(end, Next::IsEnd), map(anychar, |_| Next::NotEnd)));
     move |start: &'a str| {
         let mut i = start;
         loop {
             let (j, is_end) = next(i)?;
             match is_end {
                 Next::IsEnd(lookahead) => return Ok((i, (j, lookahead))),
-                Next::NotEnd(_) => i = j,
+                Next::NotEnd => i = j,
             }
         }
     }


### PR DESCRIPTION
New rust version has a great extension on unused item which gave:

```
$ cargo check
   Compiling askama_parser v0.2.1 (/home/imperio/rust/askama/askama_parser)
error[E0277]: expected a `FnMut(char)` closure, found `Next<_>`
   --> askama_parser/src/lib.rs:206:61
    |
206 |     let mut next = alt((map(end, Next::IsEnd), map(anychar, Next::NotEnd)));
    |                                                ---          ^^^^^^^^^^^^ expected an `FnMut(char)` closure, found `Next<_>`
    |                                                |
    |                                                required by a bound introduced by this call
    |
    = help: the trait `FnMut<(char,)>` is not implemented for `Next<_>`
note: required by a bound in `nom::combinator::map`
   --> /home/imperio/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nom-7.1.1/src/combinator/mod.rs:76:6
    |
73  | pub fn map<I, O1, O2, E, F, G>(mut parser: F, mut f: G) -> impl FnMut(I) -> IResult<I, O2, E>
    |        --- required by a bound in this function
...
76  |   G: FnMut(O1) -> O2,
    |      ^^^^^^^^^^^^^^^ required by this bound in `map`
```

So I removed it.