### PR TITLE
Implement `Template` for `&Template`

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -115,6 +115,29 @@ pub trait Template: fmt::Display {
     const MIME_TYPE: &'static str;
 }
 
+impl<T: Template + ?Sized> Template for &T {
+    #[inline]
+    fn render_into(&self, writer: &mut (impl std::fmt::Write + ?Sized)) -> Result<()> {
+        T::render_into(self, writer)
+    }
+
+    #[inline]
+    fn render(&self) -> Result<String> {
+        T::render(self)
+    }
+
+    #[inline]
+    fn write_into(&self, writer: &mut (impl std::io::Write + ?Sized)) -> std::io::Result<()> {
+        T::write_into(self, writer)
+    }
+
+    const EXTENSION: Option<&'static str> = T::EXTENSION;
+
+    const SIZE_HINT: usize = T::SIZE_HINT;
+
+    const MIME_TYPE: &'static str = T::MIME_TYPE;
+}
+
 /// Object-safe wrapper trait around [`Template`] implementers
 ///
 /// This trades reduced performance (mostly due to writing into `dyn Write`) for object safety.

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -504,3 +504,23 @@ fn test_mixed_case() {
     let template = MixedCase { xY: "foo" };
     assert_eq!(template.render().unwrap(), "foo");
 }
+
+#[allow(non_snake_case)]
+#[derive(askama::Template)]
+#[template(source = "Hello, {{ user }}!", ext = "txt")]
+struct Referenced {
+    user: &'static str,
+}
+
+#[test]
+#[allow(clippy::needless_borrows_for_generic_args)]
+fn test_referenced() {
+    fn template_to_string(template: impl Template) -> String {
+        template.to_string()
+    }
+
+    let template = Referenced { user: "person" };
+    assert_eq!(template_to_string(&&template), "Hello, person!");
+    assert_eq!(template_to_string(&template), "Hello, person!");
+    assert_eq!(template_to_string(template), "Hello, person!");
+}


### PR DESCRIPTION
`Template` does not have methods that alter `self` in any way, so a reference to a `Template` can implement `Template`, too.

This is a breaking change, because a user could have manually added `impl Template for &MyStruct {…}`.