### PR TITLE
Remove deprecated `rerun_if_templates_changed()`

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -194,15 +194,6 @@ impl fmt::Display for dyn DynTemplate {
     }
 }
 
-/// Old build script helper to rebuild crates if contained templates have changed
-///
-/// This function is now deprecated and does nothing.
-#[deprecated(
-    since = "0.8.1",
-    note = "file-level dependency tracking is handled automatically without build script"
-)]
-pub fn rerun_if_templates_changed() {}
-
 #[cfg(test)]
 mod tests {
     use std::fmt;


### PR DESCRIPTION
It's been five years. If someone upgrades their dependencies after all this time, chances are that askama is the least of their problems.