### PR TITLE
Correctly handle whitespace character(s) on filter blocks

### DIFF
--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -577,11 +577,12 @@ impl<'a> FilterBlock<'a> {
                 ws(identifier),
                 opt(|i| Expr::arguments(i, s.level.get(), false)),
                 many0(|i| filter(i, s.level.get())),
+                ws(|i| Ok((i, ()))),
                 opt(Whitespace::parse),
                 |i| s.tag_block_end(i),
             ))),
         ));
-        let (i, (pws1, _, (filter_name, params, extra_filters, nws1, _))) = start(i)?;
+        let (i, (pws1, _, (filter_name, params, extra_filters, _, nws1, _))) = start(i)?;
 
         let mut filters = Filter {
             name: filter_name,

--- a/testing/tests/filter_block.rs
+++ b/testing/tests/filter_block.rs
@@ -147,3 +147,53 @@ fn filter_block_chaining() {
     let template = F { v: "pIKA" };
     assert_eq!(template.render().unwrap(), "Hello\n  pika");
 }
+
+// This test checks that the filter chaining is working as expected when ending
+// followed by whitespace character(s).
+#[derive(Template)]
+#[template(
+    source = r#"{% filter lower|indent(2) -%}
+HELLO
+{{v}}
+{%- endfilter %}
+
+{% filter lower|indent(2)   -%}
+HELLO
+{{v}}
+{%- endfilter %}
+
+{% filter lower|indent(2) %}
+HELLO
+{{v}}
+{%- endfilter %}
+
+{% filter lower|indent(2)   %}
+HELLO
+{{v}}
+{%- endfilter %}"#,
+    ext = "txt"
+)]
+struct G {
+    v: &'static str,
+}
+
+#[test]
+fn filter_block_chaining_paren_followed_by_whitespace() {
+    let template = G { v: "pIKA" };
+    assert_eq!(
+        template.render().unwrap(),
+        r#"hello
+  pika
+
+hello
+  pika
+
+
+  hello
+  pika
+
+
+  hello
+  pika"#
+    );
+}

--- a/testing/tests/ui/filter_block_ws.rs
+++ b/testing/tests/ui/filter_block_ws.rs
@@ -1,0 +1,12 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(source = "{% filter lower|indent(2) - %}
+HELLO
+{{v}}
+{%- endfilter %}", ext = "html")]
+struct A;
+
+fn main() {
+    A.render().unwrap();
+}

--- a/testing/tests/ui/filter_block_ws.stderr
+++ b/testing/tests/ui/filter_block_ws.stderr
@@ -1,0 +1,21 @@
+error: problems parsing template source at row 1, column 27 near:
+       " %}\nHELLO\n{{v}}\n{%- endfilter %}"
+ --> tests/ui/filter_block_ws.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no method named `render` found for struct `A` in the current scope
+  --> tests/ui/filter_block_ws.rs:11:7
+   |
+8  | struct A;
+   | -------- method `render` not found for this struct
+...
+11 |     A.render().unwrap();
+   |       ^^^^^^ method not found in `A`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `render`, perhaps you need to implement it:
+           candidate #1: `Template`


### PR DESCRIPTION
"Funny" bug I encountered: the whitespace characters are not handled correctly.