### PR TITLE
Fix tests warnings

### DIFF
--- a/askama/src/error.rs
+++ b/askama/src/error.rs
@@ -90,6 +90,7 @@ impl From<::serde_yaml::Error> for Error {
 mod tests {
     use super::Error;
 
+    #[allow(dead_code)]
     trait AssertSendSyncStatic: Send + Sync + 'static {}
     impl AssertSendSyncStatic for Error {}
 }

--- a/testing/tests/size_hint.rs
+++ b/testing/tests/size_hint.rs
@@ -3,6 +3,7 @@ use askama::Template;
 macro_rules! test_size {
     ($source:literal, $expected:expr) => {{
         #[derive(Template)]
+        #[allow(dead_code)]
         #[template(source = $source, ext = "txt")]
         struct T(bool);
 


### PR DESCRIPTION
When running `cargo test`, we get:

```
warning: trait `AssertSendSyncStatic` is never used
  --> askama/src/error.rs:93:11
   |
93 |     trait AssertSendSyncStatic: Send + Sync + 'static {}
   |           ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

   Compiling askama_testing v0.1.0 (/home/imperio/rust/askama/testing)
warning: field `0` is never read
  --> testing/tests/size_hint.rs:7:18
   |
7  |         struct T(bool);
   |                - ^^^^
   |                |
   |                field in this struct
...
28 |     test_size!("{% for i in 0..1 %}12345{% endfor %}", 7);
   |     ----------------------------------------------------- in this macro invocation
   |
   = note: `#[warn(dead_code)]` on by default
   = note: this warning originates in the macro `test_size` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
7  |         struct T(());
   |                  ~~
```

This PR fixes them.