### PR TITLE
Re-export comrak for version matching.

### DIFF
--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -194,6 +194,13 @@ impl fmt::Display for dyn DynTemplate {
     }
 }
 
+/// Re-Export comrak features when markdown is included.
+/// This is to prevent any version mismatches on injected dependencies.
+#[cfg(feature = "markdown")]
+pub mod comrak {
+    pub use comrak::*;
+}
+
 #[cfg(test)]
 mod tests {
     use std::fmt;


### PR DESCRIPTION
Just added a feature gated re-export so comrak will be accesible via askama::comrak::{}; instead of having to install the correct version.

(This is my first time re-exporting so please deny if I'm incorrect).
