### PR TITLE
 Use re-exported askama::* in integration tests, etc.

### DIFF
--- a/askama_axum/Cargo.toml
+++ b/askama_axum/Cargo.toml
@@ -14,7 +14,7 @@ workspace = ".."
 readme = "README.md"
 
 [dependencies]
-askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-axum", "mime", "mime_guess"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-axum"] }
 axum-core = "0.4"
 http = "1.0"
 

--- a/askama_axum/Cargo.toml
+++ b/askama_axum/Cargo.toml
@@ -21,9 +21,8 @@ http = "1.0"
 [dev-dependencies]
 axum = { version = "0.7", default-features = false }
 http-body-util = "0.1"
-hyper = { version = "1.0", features = ["full"] }
-tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tokio = { version = "1.0", features = ["macros", "rt"] }
+tower = "0.4"
 
 [features]
 default = ["askama/default"]

--- a/askama_axum/tests/basic.rs
+++ b/askama_axum/tests/basic.rs
@@ -1,4 +1,4 @@
-use askama::Template;
+use askama_axum::Template;
 use axum::{
     body::Body,
     http::{Request, StatusCode},

--- a/askama_rocket/Cargo.toml
+++ b/askama_rocket/Cargo.toml
@@ -18,7 +18,7 @@ askama = { version = "0.13", path = "../askama", default-features = false, featu
 rocket = { version = "0.5", default-features = false }
 
 [dev-dependencies]
-futures-lite = "2.0.0"
+tokio = { version = "1.0", features = ["macros", "rt"] }
 
 [features]
 default = ["askama/default"]

--- a/askama_rocket/Cargo.toml
+++ b/askama_rocket/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-rocket", "mime", "mime_guess"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-rocket"] }
 rocket = { version = "0.5", default-features = false }
 
 [dev-dependencies]

--- a/askama_rocket/tests/basic.rs
+++ b/askama_rocket/tests/basic.rs
@@ -1,5 +1,4 @@
-use askama::Template;
-
+use askama_rocket::Template;
 use futures_lite::future::block_on;
 use rocket::http::{ContentType, Status};
 use rocket::local::asynchronous::Client;

--- a/askama_rocket/tests/basic.rs
+++ b/askama_rocket/tests/basic.rs
@@ -1,5 +1,4 @@
 use askama_rocket::Template;
-use futures_lite::future::block_on;
 use rocket::http::{ContentType, Status};
 use rocket::local::asynchronous::Client;
 use rocket::Responder;
@@ -20,18 +19,16 @@ fn hello() -> HelloTemplate<'static> {
     HelloTemplate { name: "world" }
 }
 
-#[test]
-fn test_rocket() {
-    block_on(async {
-        let rocket = rocket::build()
-            .mount("/", rocket::routes![hello])
-            .ignite()
-            .await
-            .unwrap();
-        let client = Client::untracked(rocket).await.unwrap();
-        let rsp = client.get("/").dispatch().await;
-        assert_eq!(rsp.status(), Status::Ok);
-        assert_eq!(rsp.content_type(), Some(ContentType::HTML));
-        assert_eq!(rsp.into_string().await.as_deref(), Some("Hello, world!"));
-    });
+#[tokio::test]
+async fn test_rocket() {
+    let rocket = rocket::build()
+        .mount("/", rocket::routes![hello])
+        .ignite()
+        .await
+        .unwrap();
+    let client = Client::untracked(rocket).await.unwrap();
+    let rsp = client.get("/").dispatch().await;
+    assert_eq!(rsp.status(), Status::Ok);
+    assert_eq!(rsp.content_type(), Some(ContentType::HTML));
+    assert_eq!(rsp.into_string().await.as_deref(), Some("Hello, world!"));
 }

--- a/askama_warp/Cargo.toml
+++ b/askama_warp/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-warp", "mime", "mime_guess"] }
+askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-warp"] }
 warp = { version = "0.3", default-features = false }
 
 [dev-dependencies]

--- a/askama_warp/Cargo.toml
+++ b/askama_warp/Cargo.toml
@@ -18,8 +18,7 @@ askama = { version = "0.13", path = "../askama", default-features = false, featu
 warp = { version = "0.3", default-features = false }
 
 [dev-dependencies]
-tokio-test = "0.4"
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt"] }
 
 [features]
 default = ["askama/default"]

--- a/askama_warp/tests/warp.rs
+++ b/askama_warp/tests/warp.rs
@@ -1,4 +1,4 @@
-use askama::Template;
+use askama_warp::Template;
 use warp::Filter;
 
 #[derive(Template)]


### PR DESCRIPTION
Integration crates should use `askama_…::Template` instead of `askama::Template` <https://github.com/djc/askama/issues/999#issuecomment-2041132503>.

Also some minor clean ups in the integration crates. Removes dev-dependencies:

```
Removing futures-lite v2.3.0
Removing h2 v0.4.4
Removing hyper v1.2.0
Removing parking v2.2.0
Removing tokio-test v0.4.4
```