### PR TITLE
Clean up features

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -30,10 +30,6 @@ with-axum = ["askama_derive/with-axum"]
 with-rocket = ["askama_derive/with-rocket"]
 with-warp = ["askama_derive/with-warp"]
 
-# deprecated
-mime = []
-mime_guess = []
-
 [dependencies]
 askama_derive = { version = "0.13", path = "../askama_derive" }
 askama_escape = { version = "0.10.3", path = "../askama_escape" }

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -19,12 +19,12 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["config", "humansize", "num-traits", "urlencode"]
 config = ["askama_derive/config"]
-humansize = ["askama_derive/humansize", "dep_humansize"]
-markdown = ["askama_derive/markdown", "comrak"]
-num-traits = ["askama_derive/num-traits", "dep_num_traits"]
-serde-json = ["askama_derive/serde-json", "askama_escape/json", "serde", "serde_json"]
-serde-yaml = ["askama_derive/serde-yaml", "serde", "serde_yaml"]
-urlencode = ["askama_derive/urlencode", "percent-encoding"]
+humansize = ["askama_derive/humansize", "dep:humansize"]
+markdown = ["askama_derive/markdown", "dep:comrak"]
+num-traits = ["askama_derive/num-traits", "dep:num-traits"]
+serde-json = ["askama_derive/serde-json", "askama_escape/json", "dep:serde", "dep:serde_json"]
+serde-yaml = ["askama_derive/serde-yaml", "dep:serde", "dep:serde_yaml"]
+urlencode = ["askama_derive/urlencode", "dep:percent-encoding"]
 with-actix-web = ["askama_derive/with-actix-web"]
 with-axum = ["askama_derive/with-axum"]
 with-rocket = ["askama_derive/with-rocket"]
@@ -38,8 +38,8 @@ mime_guess = []
 askama_derive = { version = "0.13", path = "../askama_derive" }
 askama_escape = { version = "0.10.3", path = "../askama_escape" }
 comrak = { version = "0.22", optional = true, default-features = false }
-dep_humansize = { package = "humansize", version = "2", optional = true }
-dep_num_traits = { package = "num-traits", version = "0.2.6", optional = true }
+humansize = { version = "2", optional = true }
+num-traits = { version = "0.2.6", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }

--- a/askama/src/error.rs
+++ b/askama/src/error.rs
@@ -32,11 +32,11 @@ pub enum Error {
     Custom(Box<dyn std::error::Error + Send + Sync>),
 
     /// json conversion error
-    #[cfg(feature = "serde_json")]
+    #[cfg(feature = "serde-json")]
     Json(::serde_json::Error),
 
     /// yaml conversion error
-    #[cfg(feature = "serde_yaml")]
+    #[cfg(feature = "serde-yaml")]
     Yaml(::serde_yaml::Error),
 }
 
@@ -45,9 +45,9 @@ impl std::error::Error for Error {
         match *self {
             Error::Fmt(ref err) => Some(err),
             Error::Custom(ref err) => Some(err.as_ref()),
-            #[cfg(feature = "serde_json")]
+            #[cfg(feature = "serde-json")]
             Error::Json(ref err) => Some(err),
-            #[cfg(feature = "serde_yaml")]
+            #[cfg(feature = "serde-yaml")]
             Error::Yaml(ref err) => Some(err),
         }
     }
@@ -58,9 +58,9 @@ impl Display for Error {
         match self {
             Error::Fmt(err) => write!(formatter, "formatting error: {err}"),
             Error::Custom(err) => write!(formatter, "{err}"),
-            #[cfg(feature = "serde_json")]
+            #[cfg(feature = "serde-json")]
             Error::Json(err) => write!(formatter, "json conversion error: {err}"),
-            #[cfg(feature = "serde_yaml")]
+            #[cfg(feature = "serde-yaml")]
             Error::Yaml(err) => write!(formatter, "yaml conversion error: {}", err),
         }
     }
@@ -72,14 +72,14 @@ impl From<fmt::Error> for Error {
     }
 }
 
-#[cfg(feature = "serde_json")]
+#[cfg(feature = "serde-json")]
 impl From<::serde_json::Error> for Error {
     fn from(err: ::serde_json::Error) -> Self {
         Error::Json(err)
     }
 }
 
-#[cfg(feature = "serde_yaml")]
+#[cfg(feature = "serde-yaml")]
 impl From<::serde_yaml::Error> for Error {
     fn from(err: ::serde_yaml::Error) -> Self {
         Error::Yaml(err)

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -21,9 +21,9 @@ pub use self::yaml::yaml;
 use crate::error::Error::Fmt;
 use askama_escape::{Escaper, MarkupDisplay};
 #[cfg(feature = "humansize")]
-use dep_humansize::{format_size_i, ToF64, DECIMAL};
+use humansize::{format_size_i, ToF64, DECIMAL};
 #[cfg(feature = "num-traits")]
-use dep_num_traits::{cast::NumCast, Signed};
+use num_traits::{cast::NumCast, Signed};
 #[cfg(feature = "percent-encoding")]
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 


### PR DESCRIPTION
* Use `dep:` prefix to suppress implicit features: Our msrv is 1.65 by now, so we can safely use this rust 1.60 feature. This is a breaking change, because users could use either `features = ["serde-json"]` or `["serde_json"]` to get the same result. With this change, only the former remains valid.

* The features `"mime"` and `"mime_guess"` are deprecated and do nothing since [#594]. Keeping such deprecated features around can still cause confusion whether one needs to select them or not. It's been 2,5 year since [#594] was merged, so I guess we can drop the features.

[#594]: https://github.com/djc/askama/pull/594