### PR TITLE
Make `|tojson` and few more filters faster 

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -21,7 +21,7 @@ default = ["config", "humansize", "num-traits", "urlencode"]
 config = ["askama_derive/config"]
 humansize = ["askama_derive/humansize", "dep_humansize"]
 num-traits = ["askama_derive/num-traits", "dep_num_traits"]
-serde-json = ["askama_derive/serde-json", "askama_escape/json", "serde", "serde_json"]
+serde-json = ["askama_derive/serde-json", "serde", "serde_json"]
 urlencode = ["askama_derive/urlencode", "percent-encoding"]
 with-actix-web = ["askama_derive/with-actix-web"]
 with-axum = ["askama_derive/with-axum"]
@@ -34,7 +34,7 @@ mime_guess = []
 
 [dependencies]
 askama_derive = { version = "0.13", path = "../askama_derive" }
-askama_escape = { version = "0.10.3", path = "../askama_escape" }
+askama_escape = { version = "0.11", path = "../askama_escape" }
 dep_humansize = { package = "humansize", version = "2", optional = true }
 dep_num_traits = { package = "num-traits", version = "0.2.6", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -41,5 +41,13 @@ percent-encoding = { version = "2.1.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "to-json"
+harness = false
+required-features = ["serde-json"]
+
 [package.metadata.docs.rs]
 features = ["config", "humansize", "num-traits", "serde-json"]

--- a/askama/benches/to-json.rs
+++ b/askama/benches/to-json.rs
@@ -1,0 +1,83 @@
+use askama::filters::json;
+use askama_escape::{Html, MarkupDisplay};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+criterion_main!(benches);
+criterion_group!(benches, functions);
+
+fn functions(c: &mut Criterion) {
+    c.bench_function("escape JSON", escape_json);
+    c.bench_function("escape JSON for HTML", escape_json_for_html);
+}
+
+fn escape_json(b: &mut criterion::Bencher<'_>) {
+    b.iter(|| {
+        for &s in STRINGS {
+            format!("{}", json(s).unwrap());
+        }
+    });
+}
+
+fn escape_json_for_html(b: &mut criterion::Bencher<'_>) {
+    b.iter(|| {
+        for &s in STRINGS {
+            format!("{}", MarkupDisplay::new_unsafe(json(s).unwrap(), Html));
+        }
+    });
+}
+
+const STRINGS: &[&str] = &[STRING_LONG, STRING_SHORT, EMPTY, NO_ESCAPE, NO_ESCAPE_LONG];
+const STRING_LONG: &str = r#"
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris consequat tellus sit
+amet ornare fermentum. Etiam nec erat ante. In at metus a orci mollis scelerisque.
+Sed eget ultrices turpis, at sollicitudin erat. Integer hendrerit nec magna quis
+venenatis. Vivamus non dolor hendrerit, vulputate velit sed, varius nunc. Quisque
+in pharetra mi. Sed ullamcorper nibh malesuada commodo porttitor. Ut scelerisque
+sodales felis quis dignissim. Morbi aliquam finibus justo, sit amet consectetur
+mauris efficitur sit amet. Donec posuere turpis felis, eu lacinia magna accumsan
+quis. Fusce egestas lacus vel fermentum tincidunt. Phasellus a nulla eget lectus
+placerat commodo at eget nisl. Fusce cursus dui quis purus accumsan auctor.
+Donec iaculis felis quis metus consectetur porttitor.
+<p>
+Etiam nibh mi, <b>accumsan</b> quis purus sed, posuere fermentum lorem. In pulvinar porta
+maximus. Fusce tincidunt lacinia tellus sit amet tincidunt. Aliquam lacus est, pulvinar
+non metus a, <b>facilisis</b> ultrices quam. Nulla feugiat leo in cursus eleifend. Suspendisse
+eget nisi ac justo sagittis interdum id a ipsum. Nulla mauris justo, scelerisque ac
+rutrum vitae, consequat vel ex.
+</p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p>
+<p>
+Sed sollicitudin <b>sem</b> mauris, at rutrum nibh egestas vel. Ut eu nisi tellus. Praesent dignissim
+orci elementum, mattis turpis eget, maximus ante. Suspendisse luctus eu felis a tempor. Morbi
+ac risus vitae sem molestie ullamcorper. Curabitur ligula augue, sollicitudin quis maximus vel,
+facilisis sed nibh. Aenean auctor magna sem, id rutrum metus convallis quis. Nullam non arcu
+dictum, lobortis erat quis, rhoncus est. Suspendisse venenatis, mi sed venenatis vehicula,
+tortor dolor egestas lectus, et efficitur turpis odio non augue. Integer velit sapien, dictum
+non egestas vitae, hendrerit sed quam. Phasellus a nunc eu erat varius imperdiet. Etiam id
+sollicitudin turpis, vitae molestie orci. Quisque ornare magna quis metus rhoncus commodo.
+Phasellus non mauris velit.
+</p>
+<p>
+Etiam dictum tellus ipsum, nec varius quam ornare vel. Cras vehicula diam nec sollicitudin
+ultricies. Pellentesque rhoncus sagittis nisl id facilisis. Nunc viverra convallis risus ut
+luctus. Aliquam vestibulum <b>efficitur massa</b>, id tempus nisi posuere a. Aliquam scelerisque
+elit justo. Nullam a ante felis. Cras vitae lorem eu nisi feugiat hendrerit. Maecenas vitae
+suscipit leo, lacinia dignissim lacus. Sed eget volutpat mi. In eu bibendum neque. Pellentesque
+finibus velit a fermentum rhoncus. Maecenas leo purus, eleifend eu lacus a, condimentum sagittis
+justo.
+</p>"#;
+const STRING_SHORT: &str = "Lorem ipsum dolor sit amet,<foo>bar&foo\"bar\\foo/bar";
+const EMPTY: &str = "";
+const NO_ESCAPE: &str = "Lorem ipsum dolor sit amet,";
+const NO_ESCAPE_LONG: &str = r#"
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque eu urna in aliquet.
+Phasellus ac nulla a urna sagittis consequat id quis est. Nullam eu ex eget erat accumsan dictum
+ac lobortis urna. Etiam fermentum ut quam at dignissim. Curabitur vestibulum luctus tellus, sit
+amet lobortis augue tempor faucibus. Nullam sed felis eget odio elementum euismod in sit amet massa.
+Vestibulum sagittis purus sit amet eros auctor, sit amet pharetra purus dapibus. Donec ornare metus
+vel dictum porta. Etiam ut nisl nisi. Nullam rutrum porttitor mi. Donec aliquam ac ipsum eget
+hendrerit. Cras faucibus, eros ut pharetra imperdiet, est tellus aliquet felis, eget convallis
+lacus ipsum eget quam. Vivamus orci lorem, maximus ac mi eget, bibendum vulputate massa. In
+vestibulum dui hendrerit, vestibulum lacus sit amet, posuere erat. Vivamus euismod massa diam,
+vulputate euismod lectus vestibulum nec. Donec sit amet massa magna. Nunc ipsum nulla, euismod
+quis lacus at, gravida maximus elit. Duis tristique, nisl nullam.
+"#;

--- a/askama/src/error.rs
+++ b/askama/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt::{self, Display};
 
 pub type Result<I, E = Error> = ::std::result::Result<I, E>;
@@ -68,6 +69,13 @@ impl From<fmt::Error> for Error {
 impl From<::serde_json::Error> for Error {
     fn from(err: ::serde_json::Error) -> Self {
         Error::Json(err)
+    }
+}
+
+impl From<Infallible> for Error {
+    #[inline]
+    fn from(value: Infallible) -> Self {
+        match value {}
     }
 }
 

--- a/askama/src/filters/json.rs
+++ b/askama/src/filters/json.rs
@@ -19,12 +19,12 @@ use serde_json::to_writer_pretty;
 /// or in apostrophes with the (optional) safe filter `'{{data|json|safe}}'`.
 /// In HTML texts the output of e.g. `<pre>{{data|json|safe}}</pre>` is safe, too.
 #[inline]
-pub fn json<S: Serialize>(s: S) -> Result<ToJson<S>, Infallible> {
+pub fn json<S: Serialize>(s: S) -> Result<impl fmt::Display, Infallible> {
     Ok(ToJson(s))
 }
 
 #[derive(Debug, Clone)]
-pub struct ToJson<S: Serialize>(S);
+struct ToJson<S: Serialize>(S);
 
 impl<S: Serialize> fmt::Display for ToJson<S> {
     #[inline]

--- a/askama/src/filters/json.rs
+++ b/askama/src/filters/json.rs
@@ -1,5 +1,6 @@
-use crate::error::{Error, Result};
-use askama_escape::JsonEscapeBuffer;
+use std::convert::Infallible;
+use std::{fmt, io, str};
+
 use serde::Serialize;
 use serde_json::to_writer_pretty;
 
@@ -17,10 +18,58 @@ use serde_json::to_writer_pretty;
 /// To use it in HTML attributes, you can either use it in quotation marks `"{{data|json}}"` as is,
 /// or in apostrophes with the (optional) safe filter `'{{data|json|safe}}'`.
 /// In HTML texts the output of e.g. `<pre>{{data|json|safe}}</pre>` is safe, too.
-pub fn json<S: Serialize>(s: S) -> Result<String> {
-    let mut writer = JsonEscapeBuffer::new();
-    to_writer_pretty(&mut writer, &s).map_err(Error::from)?;
-    Ok(writer.finish())
+#[inline]
+pub fn json<S: Serialize>(s: S) -> Result<ToJson<S>, Infallible> {
+    Ok(ToJson(s))
+}
+
+#[derive(Debug, Clone)]
+pub struct ToJson<S: Serialize>(S);
+
+impl<S: Serialize> fmt::Display for ToJson<S> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        to_writer_pretty(JsonWriter(f), &self.0).map_err(|_| fmt::Error)
+    }
+}
+
+struct JsonWriter<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
+
+impl io::Write for JsonWriter<'_, '_> {
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.write_all(bytes)?;
+        Ok(bytes.len())
+    }
+
+    #[inline]
+    fn write_all(&mut self, bytes: &[u8]) -> io::Result<()> {
+        write(self.0, bytes).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn write(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    let mut last = 0;
+    for (index, byte) in bytes.iter().enumerate() {
+        let escaped = match byte {
+            b'&' => Some(br"\u0026"),
+            b'\'' => Some(br"\u0027"),
+            b'<' => Some(br"\u003c"),
+            b'>' => Some(br"\u003e"),
+            _ => None,
+        };
+        if let Some(escaped) = escaped {
+            f.write_str(unsafe { str::from_utf8_unchecked(&bytes[last..index]) })?;
+            f.write_str(unsafe { str::from_utf8_unchecked(escaped) })?;
+            last = index + 1;
+        }
+    }
+    f.write_str(unsafe { str::from_utf8_unchecked(&bytes[last..]) })
 }
 
 #[cfg(test)]
@@ -29,12 +78,16 @@ mod tests {
 
     #[test]
     fn test_json() {
-        assert_eq!(json(true).unwrap(), "true");
-        assert_eq!(json("foo").unwrap(), r#""foo""#);
-        assert_eq!(json(true).unwrap(), "true");
-        assert_eq!(json("foo").unwrap(), r#""foo""#);
+        assert_eq!(json(true).unwrap().to_string(), "true");
+        assert_eq!(json("foo").unwrap().to_string(), r#""foo""#);
+        assert_eq!(json(true).unwrap().to_string(), "true");
+        assert_eq!(json("foo").unwrap().to_string(), r#""foo""#);
         assert_eq!(
-            json(vec!["foo", "bar"]).unwrap(),
+            json("<script>").unwrap().to_string(),
+            r#""\u003cscript\u003e""#
+        );
+        assert_eq!(
+            json(vec!["foo", "bar"]).unwrap().to_string(),
             r#"[
   "foo",
   "bar"

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -48,7 +48,8 @@ const URLENCODE_SET: &AsciiSet = &URLENCODE_STRICT_SET.remove(b'/');
 /// Askama will automatically insert the first (`Escaper`) argument,
 /// so this filter only takes a single argument of any type that implements
 /// `Display`.
-pub fn safe<E, T>(e: E, v: T) -> Result<MarkupDisplay<E, T>>
+#[inline]
+pub fn safe<E, T>(e: E, v: T) -> Result<MarkupDisplay<E, T>, Infallible>
 where
     E: Escaper,
     T: fmt::Display,
@@ -64,7 +65,8 @@ where
 ///
 /// It is possible to optionally specify an escaper other than the default for
 /// the template's extension, like `{{ val|escape("txt") }}`.
-pub fn escape<E, T>(e: E, v: T) -> Result<MarkupDisplay<E, T>>
+#[inline]
+pub fn escape<E, T>(e: E, v: T) -> Result<MarkupDisplay<E, T>, Infallible>
 where
     E: Escaper,
     T: fmt::Display,

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -215,17 +215,22 @@ pub fn format() {}
 ///
 /// A single newline becomes an HTML line break `<br>` and a new line
 /// followed by a blank line becomes a paragraph break `<p>`.
-pub fn linebreaks<T: fmt::Display>(s: T) -> Result<String> {
-    let s = s.to_string();
-    let linebroken = s.replace("\n\n", "</p><p>").replace('\n', "<br/>");
-
-    Ok(format!("<p>{linebroken}</p>"))
+#[inline]
+pub fn linebreaks(s: impl ToString) -> Result<String, Infallible> {
+    fn linebreaks(s: String) -> Result<String, Infallible> {
+        let linebroken = s.replace("\n\n", "</p><p>").replace('\n', "<br/>");
+        Ok(format!("<p>{linebroken}</p>"))
+    }
+    linebreaks(s.to_string())
 }
 
 /// Converts all newlines in a piece of plain text to HTML line breaks
-pub fn linebreaksbr<T: fmt::Display>(s: T) -> Result<String> {
-    let s = s.to_string();
-    Ok(s.replace('\n', "<br/>"))
+#[inline]
+pub fn linebreaksbr(s: impl ToString) -> Result<String, Infallible> {
+    fn linebreaksbr(s: String) -> Result<String, Infallible> {
+        Ok(s.replace('\n', "<br/>"))
+    }
+    linebreaksbr(s.to_string())
 }
 
 /// Replaces only paragraph breaks in plain text with appropriate HTML
@@ -233,34 +238,42 @@ pub fn linebreaksbr<T: fmt::Display>(s: T) -> Result<String> {
 /// A new line followed by a blank line becomes a paragraph break `<p>`.
 /// Paragraph tags only wrap content; empty paragraphs are removed.
 /// No `<br/>` tags are added.
-pub fn paragraphbreaks<T: fmt::Display>(s: T) -> Result<String> {
-    let s = s.to_string();
-    let linebroken = s.replace("\n\n", "</p><p>").replace("<p></p>", "");
-
-    Ok(format!("<p>{linebroken}</p>"))
+#[inline]
+pub fn paragraphbreaks(s: impl ToString) -> Result<String, Infallible> {
+    fn paragraphbreaks(s: String) -> Result<String, Infallible> {
+        let linebroken = s.replace("\n\n", "</p><p>").replace("<p></p>", "");
+        Ok(format!("<p>{linebroken}</p>"))
+    }
+    paragraphbreaks(s.to_string())
 }
 
 /// Converts to lowercase
-pub fn lower<T: fmt::Display>(s: T) -> Result<String> {
-    let s = s.to_string();
-    Ok(s.to_lowercase())
+#[inline]
+pub fn lower(s: impl ToString) -> Result<String, Infallible> {
+    fn lower(s: String) -> Result<String, Infallible> {
+        Ok(s.to_lowercase())
+    }
+    lower(s.to_string())
 }
 
 /// Alias for the `lower()` filter
 #[inline]
-pub fn lowercase<T: fmt::Display>(s: T) -> Result<String> {
+pub fn lowercase(s: impl ToString) -> Result<String, Infallible> {
     lower(s)
 }
 
 /// Converts to uppercase
-pub fn upper<T: fmt::Display>(s: T) -> Result<String> {
-    let s = s.to_string();
-    Ok(s.to_uppercase())
+#[inline]
+pub fn upper(s: impl ToString) -> Result<String, Infallible> {
+    fn upper(s: String) -> Result<String, Infallible> {
+        Ok(s.to_uppercase())
+    }
+    upper(s.to_string())
 }
 
 /// Alias for the `upper()` filter
 #[inline]
-pub fn uppercase<T: fmt::Display>(s: T) -> Result<String> {
+pub fn uppercase(s: impl ToString) -> Result<String, Infallible> {
     upper(s)
 }
 
@@ -285,36 +298,40 @@ pub fn trim<T: fmt::Display>(s: T) -> Result<String> {
 }
 
 /// Limit string length, appends '...' if truncated
-pub fn truncate<T: fmt::Display>(s: T, len: usize) -> Result<String> {
-    let mut s = s.to_string();
-    if s.len() > len {
-        let mut real_len = len;
-        while !s.is_char_boundary(real_len) {
-            real_len += 1;
+#[inline]
+pub fn truncate(s: impl ToString, len: usize) -> Result<String, Infallible> {
+    fn truncate(s: String, len: usize) -> Result<String, Infallible> {
+        let mut s = s.to_string();
+        if s.len() > len {
+            let mut real_len = len;
+            while !s.is_char_boundary(real_len) {
+                real_len += 1;
+            }
+            s.truncate(real_len);
+            s.push_str("...");
         }
-        s.truncate(real_len);
-        s.push_str("...");
+        Ok(s)
     }
-    Ok(s)
+    truncate(s.to_string(), len)
 }
 
 /// Indent lines with `width` spaces
-pub fn indent<T: fmt::Display>(s: T, width: usize) -> Result<String> {
-    let s = s.to_string();
+#[inline]
+pub fn indent(s: impl ToString, width: usize) -> Result<String, Infallible> {
+    fn indent(s: String, width: usize) -> Result<String, Infallible> {
+        let mut indented = String::new();
+        for (i, c) in s.char_indices() {
+            indented.push(c);
 
-    let mut indented = String::new();
-
-    for (i, c) in s.char_indices() {
-        indented.push(c);
-
-        if c == '\n' && i < s.len() - 1 {
-            for _ in 0..width {
-                indented.push(' ');
+            if c == '\n' && i < s.len() - 1 {
+                for _ in 0..width {
+                    indented.push(' ');
+                }
             }
         }
+        Ok(indented)
     }
-
-    Ok(indented)
+    indent(s.to_string(), width)
 }
 
 #[cfg(feature = "num-traits")]
@@ -391,50 +408,57 @@ where
 }
 
 /// Capitalize a value. The first character will be uppercase, all others lowercase.
-pub fn capitalize<T: fmt::Display>(s: T) -> Result<String> {
-    let s = s.to_string();
-    match s.chars().next() {
-        Some(c) => {
-            let mut replacement: String = c.to_uppercase().collect();
-            replacement.push_str(&s[c.len_utf8()..].to_lowercase());
-            Ok(replacement)
+#[inline]
+pub fn capitalize(s: impl ToString) -> Result<String, Infallible> {
+    fn capitalize(s: String) -> Result<String, Infallible> {
+        match s.chars().next() {
+            Some(c) => {
+                let mut replacement: String = c.to_uppercase().collect();
+                replacement.push_str(&s[c.len_utf8()..].to_lowercase());
+                Ok(replacement)
+            }
+            _ => Ok(s),
         }
-        _ => Ok(s),
     }
+    capitalize(s.to_string())
 }
 
 /// Centers the value in a field of a given width
-pub fn center(src: &dyn fmt::Display, dst_len: usize) -> Result<String> {
-    let src = src.to_string();
-    let len = src.len();
+#[inline]
+pub fn center(src: impl ToString, dst_len: usize) -> Result<String, Infallible> {
+    fn center(src: String, dst_len: usize) -> Result<String, Infallible> {
+        let len = src.len();
+        if dst_len <= len {
+            Ok(src)
+        } else {
+            let diff = dst_len - len;
+            let mid = diff / 2;
+            let r = diff % 2;
+            let mut buf = String::with_capacity(dst_len);
 
-    if dst_len <= len {
-        Ok(src)
-    } else {
-        let diff = dst_len - len;
-        let mid = diff / 2;
-        let r = diff % 2;
-        let mut buf = String::with_capacity(dst_len);
+            for _ in 0..mid {
+                buf.push(' ');
+            }
 
-        for _ in 0..mid {
-            buf.push(' ');
+            buf.push_str(&src);
+
+            for _ in 0..mid + r {
+                buf.push(' ');
+            }
+
+            Ok(buf)
         }
-
-        buf.push_str(&src);
-
-        for _ in 0..mid + r {
-            buf.push(' ');
-        }
-
-        Ok(buf)
     }
+    center(src.to_string(), dst_len)
 }
 
 /// Count the words in that string
-pub fn wordcount<T: fmt::Display>(s: T) -> Result<usize> {
-    let s = s.to_string();
-
-    Ok(s.split_whitespace().count())
+#[inline]
+pub fn wordcount(s: impl ToString) -> Result<usize, Infallible> {
+    fn wordcount(s: String) -> Result<usize, Infallible> {
+        Ok(s.split_whitespace().count())
+    }
+    wordcount(s.to_string())
 }
 
 #[cfg(test)]
@@ -680,10 +704,10 @@ mod tests {
 
     #[test]
     fn test_center() {
-        assert_eq!(center(&"f", 3).unwrap(), " f ".to_string());
-        assert_eq!(center(&"f", 4).unwrap(), " f  ".to_string());
-        assert_eq!(center(&"foo", 1).unwrap(), "foo".to_string());
-        assert_eq!(center(&"foo bar", 8).unwrap(), "foo bar ".to_string());
+        assert_eq!(center("f", 3).unwrap(), " f ".to_string());
+        assert_eq!(center("f", 4).unwrap(), " f  ".to_string());
+        assert_eq!(center("foo", 1).unwrap(), "foo".to_string());
+        assert_eq!(center("foo bar", 8).unwrap(), "foo bar ".to_string());
     }
 
     #[test]

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -74,6 +74,16 @@ where
     Ok(MarkupDisplay::new_unsafe(v, e))
 }
 
+/// Alias for [`escape()`]
+#[inline]
+pub fn e<E, T>(e: E, v: T) -> Result<MarkupDisplay<E, T>, Infallible>
+where
+    E: Escaper,
+    T: fmt::Display,
+{
+    escape(e, v)
+}
+
 #[cfg(feature = "humansize")]
 /// Returns adequate string representation (in KB, ..) of number of bytes
 ///
@@ -218,6 +228,7 @@ pub fn lower<T: fmt::Display>(s: T) -> Result<String> {
 }
 
 /// Alias for the `lower()` filter
+#[inline]
 pub fn lowercase<T: fmt::Display>(s: T) -> Result<String> {
     lower(s)
 }
@@ -229,6 +240,7 @@ pub fn upper<T: fmt::Display>(s: T) -> Result<String> {
 }
 
 /// Alias for the `upper()` filter
+#[inline]
 pub fn uppercase<T: fmt::Display>(s: T) -> Result<String> {
     upper(s)
 }

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -103,13 +103,13 @@ where
 /// assert_eq!(tmpl.to_string(),  "Filesize: 1.23 MB.");
 /// ```
 #[inline]
-pub fn filesizeformat(b: &impl ToF64) -> Result<FilesizeFormatFilter, Infallible> {
+pub fn filesizeformat(b: &impl ToF64) -> Result<impl fmt::Display, Infallible> {
     Ok(FilesizeFormatFilter(b.to_f64()))
 }
 
 #[cfg(feature = "humansize")]
 #[derive(Debug, Clone, Copy)]
-pub struct FilesizeFormatFilter(f64);
+struct FilesizeFormatFilter(f64);
 
 #[cfg(feature = "humansize")]
 impl fmt::Display for FilesizeFormatFilter {
@@ -139,7 +139,7 @@ impl fmt::Display for FilesizeFormatFilter {
 ///
 /// [`urlencode_strict`]: ./fn.urlencode_strict.html
 #[inline]
-pub fn urlencode<T: fmt::Display>(s: T) -> Result<UrlencodeFilter<T>, Infallible> {
+pub fn urlencode<T: fmt::Display>(s: T) -> Result<impl fmt::Display, Infallible> {
     Ok(UrlencodeFilter(s, URLENCODE_SET))
 }
 
@@ -159,12 +159,12 @@ pub fn urlencode<T: fmt::Display>(s: T) -> Result<UrlencodeFilter<T>, Infallible
 ///
 /// If you want to preserve `/`, see [`urlencode`](./fn.urlencode.html).
 #[inline]
-pub fn urlencode_strict<T: fmt::Display>(s: T) -> Result<UrlencodeFilter<T>, Infallible> {
+pub fn urlencode_strict<T: fmt::Display>(s: T) -> Result<impl fmt::Display, Infallible> {
     Ok(UrlencodeFilter(s, URLENCODE_STRICT_SET))
 }
 
 #[cfg(feature = "percent-encoding")]
-pub struct UrlencodeFilter<T>(T, &'static AsciiSet);
+struct UrlencodeFilter<T>(T, &'static AsciiSet);
 
 #[cfg(feature = "percent-encoding")]
 impl<T: fmt::Display> fmt::Display for UrlencodeFilter<T> {
@@ -216,7 +216,7 @@ pub fn format() {}
 /// A single newline becomes an HTML line break `<br>` and a new line
 /// followed by a blank line becomes a paragraph break `<p>`.
 #[inline]
-pub fn linebreaks(s: impl ToString) -> Result<String, Infallible> {
+pub fn linebreaks(s: impl ToString) -> Result<impl fmt::Display, Infallible> {
     fn linebreaks(s: String) -> Result<String, Infallible> {
         let linebroken = s.replace("\n\n", "</p><p>").replace('\n', "<br/>");
         Ok(format!("<p>{linebroken}</p>"))
@@ -226,7 +226,7 @@ pub fn linebreaks(s: impl ToString) -> Result<String, Infallible> {
 
 /// Converts all newlines in a piece of plain text to HTML line breaks
 #[inline]
-pub fn linebreaksbr(s: impl ToString) -> Result<String, Infallible> {
+pub fn linebreaksbr(s: impl ToString) -> Result<impl fmt::Display, Infallible> {
     fn linebreaksbr(s: String) -> Result<String, Infallible> {
         Ok(s.replace('\n', "<br/>"))
     }
@@ -239,7 +239,7 @@ pub fn linebreaksbr(s: impl ToString) -> Result<String, Infallible> {
 /// Paragraph tags only wrap content; empty paragraphs are removed.
 /// No `<br/>` tags are added.
 #[inline]
-pub fn paragraphbreaks(s: impl ToString) -> Result<String, Infallible> {
+pub fn paragraphbreaks(s: impl ToString) -> Result<impl fmt::Display, Infallible> {
     fn paragraphbreaks(s: String) -> Result<String, Infallible> {
         let linebroken = s.replace("\n\n", "</p><p>").replace("<p></p>", "");
         Ok(format!("<p>{linebroken}</p>"))
@@ -249,7 +249,7 @@ pub fn paragraphbreaks(s: impl ToString) -> Result<String, Infallible> {
 
 /// Converts to lowercase
 #[inline]
-pub fn lower(s: impl ToString) -> Result<String, Infallible> {
+pub fn lower(s: impl ToString) -> Result<impl fmt::Display, Infallible> {
     fn lower(s: String) -> Result<String, Infallible> {
         Ok(s.to_lowercase())
     }
@@ -258,13 +258,13 @@ pub fn lower(s: impl ToString) -> Result<String, Infallible> {
 
 /// Alias for the `lower()` filter
 #[inline]
-pub fn lowercase(s: impl ToString) -> Result<String, Infallible> {
+pub fn lowercase(s: impl ToString) -> Result<impl fmt::Display, Infallible> {
     lower(s)
 }
 
 /// Converts to uppercase
 #[inline]
-pub fn upper(s: impl ToString) -> Result<String, Infallible> {
+pub fn upper(s: impl ToString) -> Result<impl fmt::Display, Infallible> {
     fn upper(s: String) -> Result<String, Infallible> {
         Ok(s.to_uppercase())
     }
@@ -273,12 +273,12 @@ pub fn upper(s: impl ToString) -> Result<String, Infallible> {
 
 /// Alias for the `upper()` filter
 #[inline]
-pub fn uppercase(s: impl ToString) -> Result<String, Infallible> {
+pub fn uppercase(s: impl ToString) -> Result<impl fmt::Display, Infallible> {
     upper(s)
 }
 
 /// Strip leading and trailing whitespace
-pub fn trim<T: fmt::Display>(s: T) -> Result<String> {
+pub fn trim<T: fmt::Display>(s: T) -> Result<impl fmt::Display> {
     struct Collector(String);
 
     impl fmt::Write for Collector {
@@ -302,11 +302,11 @@ pub fn trim<T: fmt::Display>(s: T) -> Result<String> {
 pub fn truncate<S: fmt::Display>(
     source: S,
     remaining: usize,
-) -> Result<TruncateFilter<S>, Infallible> {
+) -> Result<impl fmt::Display, Infallible> {
     Ok(TruncateFilter { source, remaining })
 }
 
-pub struct TruncateFilter<S> {
+struct TruncateFilter<S> {
     source: S,
     remaining: usize,
 }
@@ -367,7 +367,7 @@ impl<S: fmt::Display> fmt::Display for TruncateFilter<S> {
 
 /// Indent lines with `width` spaces
 #[inline]
-pub fn indent(s: impl ToString, width: usize) -> Result<String, Infallible> {
+pub fn indent(s: impl ToString, width: usize) -> Result<impl fmt::Display, Infallible> {
     fn indent(s: String, width: usize) -> Result<String, Infallible> {
         let mut indented = String::new();
         for (i, c) in s.char_indices() {
@@ -404,7 +404,7 @@ where
 
 /// Joins iterable into a string separated by provided argument
 #[inline]
-pub fn join<I, S>(input: I, separator: S) -> Result<JoinFilter<I, S>, Infallible>
+pub fn join<I, S>(input: I, separator: S) -> Result<impl fmt::Display, Infallible>
 where
     I: IntoIterator,
     I::Item: fmt::Display,
@@ -426,7 +426,7 @@ where
 // in multiple invocations for the same object. We break this contract, because have to consume the
 // iterator, unless we want to enforce `I: Clone`, nor do we want to "memorize" the result of the
 // joined data.
-pub struct JoinFilter<I, S>(Cell<Option<(I, S)>>);
+struct JoinFilter<I, S>(Cell<Option<(I, S)>>);
 
 impl<I, S> fmt::Display for JoinFilter<I, S>
 where
@@ -459,7 +459,7 @@ where
 
 /// Capitalize a value. The first character will be uppercase, all others lowercase.
 #[inline]
-pub fn capitalize(s: impl ToString) -> Result<String, Infallible> {
+pub fn capitalize(s: impl ToString) -> Result<impl fmt::Display, Infallible> {
     fn capitalize(s: String) -> Result<String, Infallible> {
         match s.chars().next() {
             Some(c) => {
@@ -475,7 +475,7 @@ pub fn capitalize(s: impl ToString) -> Result<String, Infallible> {
 
 /// Centers the value in a field of a given width
 #[inline]
-pub fn center(src: impl ToString, dst_len: usize) -> Result<String, Infallible> {
+pub fn center(src: impl ToString, dst_len: usize) -> Result<impl fmt::Display, Infallible> {
     fn center(src: String, dst_len: usize) -> Result<String, Infallible> {
         let len = src.len();
         if dst_len <= len {
@@ -576,20 +576,20 @@ mod tests {
     #[test]
     fn test_linebreaks() {
         assert_eq!(
-            linebreaks("Foo\nBar Baz").unwrap(),
+            linebreaks("Foo\nBar Baz").unwrap().to_string(),
             "<p>Foo<br/>Bar Baz</p>"
         );
         assert_eq!(
-            linebreaks("Foo\nBar\n\nBaz").unwrap(),
+            linebreaks("Foo\nBar\n\nBaz").unwrap().to_string(),
             "<p>Foo<br/>Bar</p><p>Baz</p>"
         );
     }
 
     #[test]
     fn test_linebreaksbr() {
-        assert_eq!(linebreaksbr("Foo\nBar").unwrap(), "Foo<br/>Bar");
+        assert_eq!(linebreaksbr("Foo\nBar").unwrap().to_string(), "Foo<br/>Bar");
         assert_eq!(
-            linebreaksbr("Foo\nBar\n\nBaz").unwrap(),
+            linebreaksbr("Foo\nBar\n\nBaz").unwrap().to_string(),
             "Foo<br/>Bar<br/><br/>Baz"
         );
     }
@@ -597,38 +597,40 @@ mod tests {
     #[test]
     fn test_paragraphbreaks() {
         assert_eq!(
-            paragraphbreaks("Foo\nBar Baz").unwrap(),
+            paragraphbreaks("Foo\nBar Baz").unwrap().to_string(),
             "<p>Foo\nBar Baz</p>"
         );
         assert_eq!(
-            paragraphbreaks("Foo\nBar\n\nBaz").unwrap(),
+            paragraphbreaks("Foo\nBar\n\nBaz").unwrap().to_string(),
             "<p>Foo\nBar</p><p>Baz</p>"
         );
         assert_eq!(
-            paragraphbreaks("Foo\n\n\n\n\nBar\n\nBaz").unwrap(),
+            paragraphbreaks("Foo\n\n\n\n\nBar\n\nBaz")
+                .unwrap()
+                .to_string(),
             "<p>Foo</p><p>\nBar</p><p>Baz</p>"
         );
     }
 
     #[test]
     fn test_lower() {
-        assert_eq!(lower("Foo").unwrap(), "foo");
-        assert_eq!(lower("FOO").unwrap(), "foo");
-        assert_eq!(lower("FooBar").unwrap(), "foobar");
-        assert_eq!(lower("foo").unwrap(), "foo");
+        assert_eq!(lower("Foo").unwrap().to_string(), "foo");
+        assert_eq!(lower("FOO").unwrap().to_string(), "foo");
+        assert_eq!(lower("FooBar").unwrap().to_string(), "foobar");
+        assert_eq!(lower("foo").unwrap().to_string(), "foo");
     }
 
     #[test]
     fn test_upper() {
-        assert_eq!(upper("Foo").unwrap(), "FOO");
-        assert_eq!(upper("FOO").unwrap(), "FOO");
-        assert_eq!(upper("FooBar").unwrap(), "FOOBAR");
-        assert_eq!(upper("foo").unwrap(), "FOO");
+        assert_eq!(upper("Foo").unwrap().to_string(), "FOO");
+        assert_eq!(upper("FOO").unwrap().to_string(), "FOO");
+        assert_eq!(upper("FooBar").unwrap().to_string(), "FOOBAR");
+        assert_eq!(upper("foo").unwrap().to_string(), "FOO");
     }
 
     #[test]
     fn test_trim() {
-        assert_eq!(trim(" Hello\tworld\t").unwrap(), "Hello\tworld");
+        assert_eq!(trim(" Hello\tworld\t").unwrap().to_string(), "Hello\tworld");
     }
 
     #[test]
@@ -658,11 +660,11 @@ mod tests {
 
     #[test]
     fn test_indent() {
-        assert_eq!(indent("hello", 2).unwrap(), "hello");
-        assert_eq!(indent("hello\n", 2).unwrap(), "hello\n");
-        assert_eq!(indent("hello\nfoo", 2).unwrap(), "hello\n  foo");
+        assert_eq!(indent("hello", 2).unwrap().to_string(), "hello");
+        assert_eq!(indent("hello\n", 2).unwrap().to_string(), "hello\n");
+        assert_eq!(indent("hello\nfoo", 2).unwrap().to_string(), "hello\n  foo");
         assert_eq!(
-            indent("hello\nfoo\n bar", 4).unwrap(),
+            indent("hello\nfoo\n bar", 4).unwrap().to_string(),
             "hello\n    foo\n     bar"
         );
     }
@@ -741,23 +743,32 @@ mod tests {
 
     #[test]
     fn test_capitalize() {
-        assert_eq!(capitalize("foo").unwrap(), "Foo".to_string());
-        assert_eq!(capitalize("f").unwrap(), "F".to_string());
-        assert_eq!(capitalize("fO").unwrap(), "Fo".to_string());
-        assert_eq!(capitalize("").unwrap(), "".to_string());
-        assert_eq!(capitalize("FoO").unwrap(), "Foo".to_string());
-        assert_eq!(capitalize("foO BAR").unwrap(), "Foo bar".to_string());
-        assert_eq!(capitalize("äØÄÅÖ").unwrap(), "Äøäåö".to_string());
-        assert_eq!(capitalize("ß").unwrap(), "SS".to_string());
-        assert_eq!(capitalize("ßß").unwrap(), "SSß".to_string());
+        assert_eq!(capitalize("foo").unwrap().to_string(), "Foo".to_string());
+        assert_eq!(capitalize("f").unwrap().to_string(), "F".to_string());
+        assert_eq!(capitalize("fO").unwrap().to_string(), "Fo".to_string());
+        assert_eq!(capitalize("").unwrap().to_string(), "".to_string());
+        assert_eq!(capitalize("FoO").unwrap().to_string(), "Foo".to_string());
+        assert_eq!(
+            capitalize("foO BAR").unwrap().to_string(),
+            "Foo bar".to_string()
+        );
+        assert_eq!(
+            capitalize("äØÄÅÖ").unwrap().to_string(),
+            "Äøäåö".to_string()
+        );
+        assert_eq!(capitalize("ß").unwrap().to_string(), "SS".to_string());
+        assert_eq!(capitalize("ßß").unwrap().to_string(), "SSß".to_string());
     }
 
     #[test]
     fn test_center() {
-        assert_eq!(center("f", 3).unwrap(), " f ".to_string());
-        assert_eq!(center("f", 4).unwrap(), " f  ".to_string());
-        assert_eq!(center("foo", 1).unwrap(), "foo".to_string());
-        assert_eq!(center("foo bar", 8).unwrap(), "foo bar ".to_string());
+        assert_eq!(center("f", 3).unwrap().to_string(), " f ".to_string());
+        assert_eq!(center("f", 4).unwrap().to_string(), " f  ".to_string());
+        assert_eq!(center("foo", 1).unwrap().to_string(), "foo".to_string());
+        assert_eq!(
+            center("foo bar", 8).unwrap().to_string(),
+            "foo bar ".to_string()
+        );
     }
 
     #[test]

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -59,7 +59,6 @@
 //!   in the configuration file. The default syntax , "default",  is the one
 //!   provided by Askama.
 
-#![forbid(unsafe_code)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 

--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_escape"
-version = "0.10.3"
+version = "0.11.0"
 description = "Optimized HTML escaping code, extracted from Askama"
 documentation = "https://docs.rs/askama_escape"
 keywords = ["html", "escaping"]
@@ -17,9 +17,6 @@ maintenance = { status = "actively-developed" }
 
 [dev-dependencies]
 criterion = "0.5"
-
-[features]
-json = []
 
 [[bench]]
 name = "all"

--- a/askama_escape/src/lib.rs
+++ b/askama_escape/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(any(feature = "json", test)), no_std)]
+#![no_std]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unreachable_pub)]
 
@@ -165,51 +165,10 @@ pub trait Escaper {
         W: Write;
 }
 
-/// Escape chevrons, ampersand and apostrophes for use in JSON
-#[cfg(feature = "json")]
-#[derive(Debug, Clone, Default)]
-pub struct JsonEscapeBuffer(Vec<u8>);
-
-#[cfg(feature = "json")]
-impl JsonEscapeBuffer {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn finish(self) -> String {
-        unsafe { String::from_utf8_unchecked(self.0) }
-    }
-}
-
-#[cfg(feature = "json")]
-impl std::io::Write for JsonEscapeBuffer {
-    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-        let mut last = 0;
-        for (index, byte) in bytes.iter().enumerate() {
-            let escaped = match byte {
-                b'&' => Some(br"\u0026"),
-                b'\'' => Some(br"\u0027"),
-                b'<' => Some(br"\u003c"),
-                b'>' => Some(br"\u003e"),
-                _ => None,
-            };
-            if let Some(escaped) = escaped {
-                self.0.extend(&bytes[last..index]);
-                self.0.extend(escaped);
-                last = index + 1;
-            }
-        }
-        self.0.extend(&bytes[last..]);
-        Ok(bytes.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use super::*;
     use std::string::ToString;
 


### PR DESCRIPTION
This ~~proof-of-concept~~ PR changes the filter `|tojson` so that it does not collect the serialized data into a string, but writes the data into the target writer directly.

This makes the benchmark run 81% (only serializing) or 39% (serializing and escaping for HTML) faster. The benchmarked data is not a fair representation for the data you would most likely escape, though.