### PR TITLE
Implement `Render` even if parsing failed

### DIFF
--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -36,7 +36,7 @@ impl Heritage<'_> {
 
 type BlockAncestry<'a> = HashMap<&'a str, Vec<(&'a Context<'a>, &'a BlockDef<'a>)>>;
 
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub(crate) struct Context<'a> {
     pub(crate) nodes: &'a [Node<'a>],
     pub(crate) extends: Option<Rc<Path>>,

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -332,6 +332,14 @@ impl TemplateArgs {
         Ok(args)
     }
 
+    pub(crate) fn fallback() -> Self {
+        Self {
+            source: Some(Source::Source("".to_string())),
+            ext: Some("txt".to_string()),
+            ..Self::default()
+        }
+    }
+
     pub(crate) fn config(&self) -> Result<String, CompileError> {
         read_config_file(self.config.as_deref())
     }

--- a/testing/tests/ui/filter_block_ws.stderr
+++ b/testing/tests/ui/filter_block_ws.stderr
@@ -6,16 +6,3 @@ error: failed to parse template source at row 1, column 27 near:
   |          ^^^^^^^^
   |
   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0599]: no method named `render` found for struct `A` in the current scope
-  --> tests/ui/filter_block_ws.rs:11:7
-   |
-8  | struct A;
-   | -------- method `render` not found for this struct
-...
-11 |     A.render().unwrap();
-   |       ^^^^^^ method not found in `A`
-   |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `render`, perhaps you need to implement it:
-           candidate #1: `Template`


### PR DESCRIPTION
This makes error messages much more readable.