### PR TITLE
Add `deref` builtin filter

### DIFF
--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -339,8 +339,6 @@ pub fn wordcount<T: fmt::Display>(s: T) -> Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "num-traits")]
-    use std::f64::INFINITY;
 
     #[cfg(feature = "humansize")]
     #[test]
@@ -496,8 +494,8 @@ mod tests {
         assert_eq!(into_f64(1).unwrap(), 1.0_f64);
         assert_eq!(into_f64(1.9).unwrap(), 1.9_f64);
         assert_eq!(into_f64(-1.9).unwrap(), -1.9_f64);
-        assert_eq!(into_f64(INFINITY as f32).unwrap(), INFINITY);
-        assert_eq!(into_f64(-INFINITY as f32).unwrap(), -INFINITY);
+        assert_eq!(into_f64(f32::INFINITY).unwrap(), f64::INFINITY);
+        assert_eq!(into_f64(-f32::INFINITY).unwrap(), -f64::INFINITY);
     }
 
     #[cfg(feature = "num-traits")]
@@ -508,7 +506,7 @@ mod tests {
         assert_eq!(into_isize(-1.9).unwrap(), -1_isize);
         assert_eq!(into_isize(1.5_f64).unwrap(), 1_isize);
         assert_eq!(into_isize(-1.5_f64).unwrap(), -1_isize);
-        match into_isize(INFINITY) {
+        match into_isize(f64::INFINITY) {
             Err(Fmt(fmt::Error)) => {}
             _ => panic!("Should return error of type Err(Fmt(fmt::Error))"),
         };

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -1230,6 +1230,7 @@ impl<'a> Generator<'a> {
     ) -> Result<DisplayWrap, CompileError> {
         match name {
             "as_ref" => return self._visit_as_ref_filter(buf, args),
+            "deref" => return self._visit_deref_filter(buf, args),
             "escape" | "e" => return self._visit_escape_filter(buf, args),
             "fmt" => return self._visit_fmt_filter(buf, args),
             "format" => return self._visit_format_filter(buf, args),
@@ -1259,6 +1260,20 @@ impl<'a> Generator<'a> {
             _ => return Err("unexpected argument(s) in `as_ref` filter".into()),
         };
         buf.write("&");
+        self.visit_expr(buf, arg)?;
+        Ok(DisplayWrap::Unwrapped)
+    }
+
+    fn _visit_deref_filter(
+        &mut self,
+        buf: &mut Buffer,
+        args: &[Expr<'_>],
+    ) -> Result<DisplayWrap, CompileError> {
+        let arg = match args {
+            [arg] => arg,
+            _ => return Err("unexpected argument(s) in `deref` filter".into()),
+        };
+        buf.write("*");
         self.visit_expr(buf, arg)?;
         Ok(DisplayWrap::Unwrapped)
     }

--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -24,6 +24,7 @@ Enable it with Cargo features (see below for more information).
   [`as_ref`][#as_ref],
   [`capitalize`][#capitalize],
   [`center`][#center],
+  [`deref`][#deref],
   [`escape|e`][#escape],
   [`filesizeformat`][#filesizeformat],
   [`fmt`][#fmt],
@@ -106,6 +107,24 @@ Centers the value in a field of a given width:
 Output:
 ```
 -  a  -
+```
+
+### deref
+[#deref]: #deref
+
+Dereferences the given argument.
+
+```
+{% let s = String::from("a")|as_ref %}
+{% if s|deref == String::from("b") %}
+{% endif %}
+```
+
+will become:
+
+```
+let s = &String::from("a");
+if *s == String::from("b") {}
 ```
 
 ### escape | e

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -311,7 +311,12 @@ fn test_json_script() {
 }
 
 #[derive(askama::Template)]
-#[template(source = "{% let word = s|as_ref %}{{ word }}", ext = "html")]
+#[template(
+    source = r#"{% let word = s|as_ref %}{{ word }}
+{%- let hello = String::from("hello") %}
+{%- if word|deref == hello %}1{% else %}2{% endif %}"#,
+    ext = "html"
+)]
 struct LetBorrow {
     s: String,
 }
@@ -321,5 +326,5 @@ fn test_let_borrow() {
     let template = LetBorrow {
         s: "hello".to_owned(),
     };
-    assert_eq!(template.render().unwrap(), "hello")
+    assert_eq!(template.render().unwrap(), "hello1")
 }

--- a/testing/tests/inheritance.rs
+++ b/testing/tests/inheritance.rs
@@ -331,6 +331,12 @@ fn test_flat_deep() {
 #[template(path = "let-base.html")]
 struct LetBase {}
 
+#[test]
+fn test_let_base() {
+    let t = LetBase {};
+    assert_eq!(t.render().unwrap(), "");
+}
+
 #[derive(Template)]
 #[template(path = "let-child.html")]
 struct LetChild {}

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -350,6 +350,12 @@ impl FunctionTemplate {
     }
 }
 
+#[test]
+fn test_fn() {
+    let t = FunctionTemplate;
+    assert_eq!(t.render().unwrap(), "Hello, world1234!");
+}
+
 #[derive(Template)]
 #[template(source = "  {# foo -#} ", ext = "txt")]
 struct CommentTemplate {}


### PR DESCRIPTION
Since we have `as_ref`, sometimes it's better to remove references than to add more. :)