### PR TITLE
Make JSON prettifying optional

### DIFF
--- a/askama/benches/to-json.rs
+++ b/askama/benches/to-json.rs
@@ -13,7 +13,7 @@ fn functions(c: &mut Criterion) {
 fn escape_json(b: &mut criterion::Bencher<'_>) {
     b.iter(|| {
         for &s in STRINGS {
-            format!("{}", json(s).unwrap());
+            format!("{}", json(s, ()).unwrap());
         }
     });
 }
@@ -21,7 +21,7 @@ fn escape_json(b: &mut criterion::Bencher<'_>) {
 fn escape_json_for_html(b: &mut criterion::Bencher<'_>) {
     b.iter(|| {
         for &s in STRINGS {
-            format!("{}", MarkupDisplay::new_unsafe(json(s).unwrap(), Html));
+            format!("{}", MarkupDisplay::new_unsafe(json(s, ()).unwrap(), Html));
         }
     });
 }

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -12,7 +12,7 @@ use std::fmt::{self, Write};
 #[cfg(feature = "serde-json")]
 mod json;
 #[cfg(feature = "serde-json")]
-pub use self::json::json;
+pub use self::json::{json, AsIndent};
 
 use askama_escape::{Escaper, MarkupDisplay};
 #[cfg(feature = "humansize")]

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -1272,12 +1272,14 @@ impl<'a> Generator<'a> {
             return Err("the `json` filter requires the `serde-json` feature to be enabled".into());
         }
 
-        if args.len() != 1 {
-            return Err("unexpected argument(s) in `json` filter".into());
-        }
         buf.write(CRATE);
         buf.write("::filters::json(");
         self._visit_args(buf, args)?;
+        match args.len() {
+            1 => buf.write(", ()"),
+            2 => {}
+            _ => return Err("unexpected argument(s) in `json` filter".into()),
+        }
         buf.write(")?");
         Ok(DisplayWrap::Unwrapped)
     }

--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -415,6 +415,18 @@ Ugly: <script>var data = "{{data|json}}";</script>
 Ugly: <script>var data = '{{data|json|safe}}';</script>
 ```
 
+By default, a compact representation of the data is generated, i.e. no whitespaces are generated
+between individual values. To generate a readable representation, you can either pass an integer
+how many spaces to use as indentation, or you can pass a string that gets used as prefix:
+
+```jinja2
+Prefix with four spaces:
+<textarea>{{data|tojson(4)}}</textarea>
+
+Prefix with two &nbsp; characters:
+<p>{{data|tojson("\u{a0}\u{a0}")}}</p>
+```
+
 ## Custom Filters
 [#custom-filters]: #custom-filters
 

--- a/testing/templates/allow-whitespaces.html
+++ b/testing/templates/allow-whitespaces.html
@@ -25,11 +25,11 @@
 {% let hash = &nested_1.nested_2.hash %}
 #}
 
-{{ array| json }}
-{{ array[..]| json }}{{ array [ .. ]| json }}
-{{ array[1..2]| json }}{{ array [ 1 .. 2 ]| json }}
-{{ array[1..=2]| json }}{{ array [ 1 ..= 2 ]| json }}
-{{ array[(0+1)..(3-1)]| json }}{{ array [ ( 0 + 1 ) .. ( 3 - 1 ) ]| json }}
+{{ array| json(2) }}
+{{ array[..]| json(2) }}{{ array [ .. ]| json(2) }}
+{{ array[1..2]| json(2) }}{{ array [ 1 .. 2 ]| json(2) }}
+{{ array[1..=2]| json(2) }}{{ array [ 1 ..= 2 ]| json(2) }}
+{{ array[(0+1)..(3-1)]| json(2) }}{{ array [ ( 0 + 1 ) .. ( 3 - 1 ) ]| json(2) }}
 
 {{-1}}{{ -1 }}{{ - 1 }}
 {{1+2}}{{ 1+2 }}{{ 1 +2 }}{{ 1+ 2 }} {{ 1 + 2 }}

--- a/testing/templates/json.html
+++ b/testing/templates/json.html
@@ -1,4 +1,0 @@
-{
-  "foo": "{{ foo }}",
-  "bar": {{ bar|json|safe }}
-}

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -164,7 +164,13 @@ fn test_vec_join() {
 
 #[cfg(feature = "serde-json")]
 #[derive(Template)]
-#[template(path = "json.html")]
+#[template(
+    source = r#"{
+  "foo": "{{ foo }}",
+  "bar": {{ bar|json|safe }}
+}"#,
+    ext = "txt"
+)]
 struct JsonTemplate<'a> {
     foo: &'a str,
     bar: &'a Value,
@@ -175,6 +181,37 @@ struct JsonTemplate<'a> {
 fn test_json() {
     let val = json!({"arr": [ "one", 2, true, null ]});
     let t = JsonTemplate {
+        foo: "a",
+        bar: &val,
+    };
+    assert_eq!(
+        t.render().unwrap(),
+        r#"{
+  "foo": "a",
+  "bar": {"arr":["one",2,true,null]}
+}"#
+    );
+}
+
+#[cfg(feature = "serde-json")]
+#[derive(Template)]
+#[template(
+    source = r#"{
+  "foo": "{{ foo }}",
+  "bar": {{ bar|json(2)|safe }}
+}"#,
+    ext = "txt"
+)]
+struct PrettyJsonTemplate<'a> {
+    foo: &'a str,
+    bar: &'a Value,
+}
+
+#[cfg(feature = "serde-json")]
+#[test]
+fn test_pretty_json() {
+    let val = json!({"arr": [ "one", 2, true, null ]});
+    let t = PrettyJsonTemplate {
         foo: "a",
         bar: &val,
     };
@@ -193,6 +230,39 @@ fn test_json() {
 }
 }"#
     );
+}
+
+#[cfg(feature = "serde-json")]
+#[derive(Template)]
+#[template(source = r#"{{ bar|json(indent)|safe }}"#, ext = "txt")]
+struct DynamicJsonTemplate<'a> {
+    bar: &'a Value,
+    indent: Option<&'a str>,
+}
+
+#[cfg(feature = "serde-json")]
+#[test]
+fn test_dynamic_json() {
+    let val = json!({"arr": ["one", 2]});
+    let t = DynamicJsonTemplate {
+        bar: &val,
+        indent: Some("?"),
+    };
+    assert_eq!(
+        t.render().unwrap(),
+        r#"{
+?"arr": [
+??"one",
+??2
+?]
+}"#
+    );
+
+    let t = DynamicJsonTemplate {
+        bar: &val,
+        indent: None,
+    };
+    assert_eq!(t.render().unwrap(), r#"{"arr":["one",2]}"#);
 }
 
 #[derive(Template)]


### PR DESCRIPTION
This PR adds an optional argument to the `|tojson` filter, which controls if the serialized JSON data gets prettified or not. The arguments works the same as flask's [`|tojson`][flask] filter, which passes the argument to python's [`json.dumps()`][python]:

* Omitting the argument, providing a negative integer, or `None`, then compact JSON data is generated.
* Providing a non-negative integer, then this amount of ASCII spaces is used to indent the data. (Capped to 16 characters.)
* Providing a string, then this string is used as prefix. No attempts are made to ensure that the prefix actually consists of whitespaces, because chances are, that if you provide e.g. `&nsbp;`, then you are doing it intentionally.

This is a breaking change, because it changes the default behavior to not prettify the data. This is done intentionally, because this is how it works in flask.

[flask]: https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.tojson
[python]: https://docs.python.org/3/library/json.html#json.dump

---

This PR is based on #1008, i.e. only the last commit is actually part of this PR.

Resolves #1019.