### PR TITLE
fuzz: Add cifuzz integration

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,24 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   steps:
+   - name: Build Fuzzers
+     id: build
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'askama'
+       language: rust
+   - name: Run Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'askama'
+       language: rust
+       fuzz-seconds: 180
+   - name: Upload Crash
+     uses: actions/upload-artifact@v3
+     if: failure() && steps.build.outcome == 'success'
+     with:
+       name: artifacts
+       path: ./out/artifacts


### PR DESCRIPTION
Add cifuzz workflow action to have fuzzers build and run on each PR.
This is a service offered by oss-fuzz where askama already runs. cifuzz can help catch shallow bugs, regressions and fuzzing build issues before they are merged into the repository, to do this fuzzing will be run for ~5min.