### PR TITLE
Re-add `{% set %}` as alias for `{% let %}`

### DIFF
--- a/askama_parser/src/node.rs
+++ b/askama_parser/src/node.rs
@@ -69,7 +69,7 @@ impl<'a> Node<'a> {
 
         let func = match tag {
             "call" => |i, s| wrap(Self::Call, Call::parse(i, s)),
-            "let" => |i, s| wrap(Self::Let, Let::parse(i, s)),
+            "let" | "set" => |i, s| wrap(Self::Let, Let::parse(i, s)),
             "if" => |i, s| wrap(Self::If, If::parse(i, s)),
             "for" => |i, s| wrap(|n| Self::Loop(Box::new(n)), Loop::parse(i, s)),
             "match" => |i, s| wrap(Self::Match, Match::parse(i, s)),

--- a/askama_parser/src/tests.rs
+++ b/askama_parser/src/tests.rs
@@ -932,3 +932,15 @@ fn fuzzed_comment_depth() {
         .expect("timeout");
     test.join().unwrap();
 }
+
+#[test]
+fn let_set() {
+    assert_eq!(
+        Ast::from_str("{% let a %}", None, &Syntax::default())
+            .unwrap()
+            .nodes(),
+        Ast::from_str("{% set a %}", None, &Syntax::default())
+            .unwrap()
+            .nodes(),
+    );
+}


### PR DESCRIPTION
Commit [615fb82] introduced a regression. `{% set %}` and `{% let %}` should be interchangeable, but only the latter syntax works.

This PR fixes the problem, and adds a regression test.

[615fb82]: <https://github.com/djc/askama/commit/615fb82c65f38071b1ce1d9edab52cc0009e985d>