### PR TITLE
Fix block partial rendering

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -989,6 +989,10 @@ impl<'a> Generator<'a> {
         if block_fragment_write {
             self.buf_writable.discard = true;
         }
+        // If we are rendering a specific block and the discard changed, it means that we're done
+        // with the block we want to render and that from this point, everything will be discarded.
+        //
+        // To get this block content rendered as well, we need to write to the buffer before then.
         if buf.discard != prev_buf_discard {
             self.write_buf_writable(buf)?;
         }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -90,6 +90,7 @@ impl<'a> Generator<'a> {
         buf.write(CRATE);
         buf.writeln("::Result<()> {")?;
 
+        buf.discard = self.buf_writable.discard;
         // Make sure the compiler understands that the generated code depends on the template files.
         for path in self.contexts.keys() {
             // Skip the fake path of templates defined in rust source.
@@ -113,6 +114,7 @@ impl<'a> Generator<'a> {
         } else {
             self.handle(ctx, ctx.nodes, buf, AstLevel::Top)
         }?;
+        buf.discard = false;
 
         self.flush_ws(Ws(None, None));
         buf.write(CRATE);
@@ -986,6 +988,9 @@ impl<'a> Generator<'a> {
         // Restore the original buffer discarding state
         if block_fragment_write {
             self.buf_writable.discard = true;
+        }
+        if buf.discard != prev_buf_discard {
+            self.write_buf_writable(buf)?;
         }
         buf.discard = prev_buf_discard;
 

--- a/testing/tests/block_fragments.rs
+++ b/testing/tests/block_fragments.rs
@@ -103,3 +103,21 @@ fn test_specific_block() {
     let t = RenderInPlace { s1 };
     assert_eq!(t.render().unwrap(), "\nSection: [abc]\n");
 }
+
+#[derive(Template)]
+#[template(
+    source = r#"{% block empty %}
+{% endblock %}
+
+{% if let Some(var) = var %}
+{{ var }}
+{% endif %}"#,
+    block = "empty",
+    ext = "txt"
+)]
+struct Empty {}
+
+#[test]
+fn test_render_only_block() {
+    assert_eq!(Empty {}.render().unwrap(), "\n");
+}


### PR DESCRIPTION
Fixes #1052.

It didn't take into account that there would be other elements at the top level. Now it does.