### PR TITLE
Remove unnecessary allocs of discarded content

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -90,6 +90,7 @@ impl<'a> Generator<'a> {
         buf.write(CRATE);
         buf.writeln("::Result<()> {")?;
 
+        buf.discard = self.buf_writable.discard;
         // Make sure the compiler understands that the generated code depends on the template files.
         for path in self.contexts.keys() {
             // Skip the fake path of templates defined in rust source.
@@ -113,6 +114,7 @@ impl<'a> Generator<'a> {
         } else {
             self.handle(ctx, ctx.nodes, buf, AstLevel::Top)
         }?;
+        buf.discard = false;
 
         self.flush_ws(Ws(None, None));
         buf.write(CRATE);
@@ -986,6 +988,9 @@ impl<'a> Generator<'a> {
         // Restore the original buffer discarding state
         if block_fragment_write {
             self.buf_writable.discard = true;
+        }
+        if buf.discard != prev_buf_discard {
+            self.write_buf_writable(buf)?;
         }
         buf.discard = prev_buf_discard;
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -365,7 +365,7 @@ impl<'a> Generator<'a> {
                 }
 
                 if let Some(target) = target {
-                    let mut expr_buf = Buffer::new(0);
+                    let mut expr_buf = Buffer::from_buf_parameters(buf, 0);
                     buf.write("let ");
                     // If this is a chain condition, then we need to declare the variable after the
                     // left expression has been handled but before the right expression is handled
@@ -596,8 +596,8 @@ impl<'a> Generator<'a> {
         buf.writeln("{")?;
         self.prepare_ws(def.ws1);
 
-        let mut names = Buffer::new(0);
-        let mut values = Buffer::new(0);
+        let mut names = Buffer::from_buf_parameters(buf, 0);
+        let mut values = Buffer::from_buf_parameters(buf, 0);
         let mut is_first_variable = true;
         if args.len() != def.args.len() {
             return Err(CompileError::from(format!(
@@ -661,7 +661,7 @@ impl<'a> Generator<'a> {
                         .insert(Cow::Borrowed(arg), LocalMeta::with_ref(var));
                 }
                 Expr::Attr(obj, attr) => {
-                    let mut attr_buf = Buffer::new(0);
+                    let mut attr_buf = Buffer::from_buf_parameters(buf, 0);
                     self.visit_attr(&mut attr_buf, obj, attr)?;
 
                     let var = self.locals.resolve(&attr_buf.buf).unwrap_or(attr_buf.buf);
@@ -750,7 +750,7 @@ impl<'a> Generator<'a> {
 
         self.buf_writable.buf = current_buf;
 
-        let mut filter_buf = Buffer::new(buf.indent);
+        let mut filter_buf = Buffer::from_buf_parameters(buf, buf.indent);
         let Filter {
             name: filter_name,
             arguments,
@@ -876,7 +876,7 @@ impl<'a> Generator<'a> {
             return buf.writeln(";");
         };
 
-        let mut expr_buf = Buffer::new(0);
+        let mut expr_buf = Buffer::from_buf_parameters(buf, 0);
         self.visit_expr(&mut expr_buf, val)?;
 
         let shadowed = self.is_shadowing_variable(&l.var)?;
@@ -1844,6 +1844,15 @@ impl Buffer {
             indent,
             start: true,
             discard: false,
+        }
+    }
+
+    fn from_buf_parameters(other: &Buffer, indent: u8) -> Self {
+        Self {
+            buf: String::new(),
+            indent,
+            start: true,
+            discard: other.discard,
         }
     }
 

--- a/testing/tests/block_fragments.rs
+++ b/testing/tests/block_fragments.rs
@@ -103,3 +103,21 @@ fn test_specific_block() {
     let t = RenderInPlace { s1 };
     assert_eq!(t.render().unwrap(), "\nSection: [abc]\n");
 }
+
+#[derive(Template)]
+#[template(
+    source = r#"{% block empty %}
+{% endblock %}
+
+{% if let Some(var) = var %}
+{{ var }}
+{% endif %}"#,
+    block = "empty",
+    ext = "txt"
+)]
+struct Empty {}
+
+#[test]
+fn test_render_only_block() {
+    assert_eq!(Empty {}.render().unwrap(), "\n");
+}


### PR DESCRIPTION
Follow-up of https://github.com/djc/askama/pull/1054 (first commit comes from there).

Since the content is discarded, no point into allocating memory for it.