### PR TITLE
Add urlencode to filters.md

### DIFF
--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -40,6 +40,7 @@ Enable it with Cargo features (see below for more information).
   * [`trim`][#trim]
   * [`truncate`][#truncate]
   * [`upper|uppercase`][#upper]
+  * [`urlencode`][#urlencode]
   * [`wordcount`][#wordcount]
 
 * **[Optional / feature gated filters][#optional-filters]:**  
@@ -397,6 +398,21 @@ Output:
 
 ```
 HELLO
+```
+
+### urlencode
+[#urlencode]: #urlencode
+
+Percent encodes the string. Replaces reserved characters with the % escape character followed by a byte value as two hexadecimal digits.
+
+```
+hello?world
+```
+
+Output:
+
+```
+hello%3Fworld
 ```
 
 ### wordcount


### PR DESCRIPTION
The urlencode filter was missing from the documentation. This adds it.

I placed it under `Built-in filters` rather than `Optional / feature gated filters`, even though it is behind the [urlencode](https://github.com/djc/askama/blob/ab5c6a3b39b53d63489160f0c381ae3c9ac7b806/askama/Cargo.toml#L20) feature gate, on the basis that this is in the default feature list. Let me know if preferred in the optional filters.