### PR TITLE
Add a failing test for using include within a block fragment

### DIFF
--- a/testing/templates/fragment-include.html
+++ b/testing/templates/fragment-include.html
@@ -1,0 +1,9 @@
+{% extends "fragment-base.html" %}
+
+{% block body %}
+{% include "included.html" %}
+{% endblock %}
+
+{% block other_body %}
+<p>Don't render me.</p>
+{% endblock %}

--- a/testing/tests/block_fragments.rs
+++ b/testing/tests/block_fragments.rs
@@ -103,3 +103,15 @@ fn test_specific_block() {
     let t = RenderInPlace { s1 };
     assert_eq!(t.render().unwrap(), "\nSection: [abc]\n");
 }
+
+#[derive(Template)]
+#[template(path = "fragment-include.html", block = "body")]
+struct FragmentInclude<'a> {
+    s: &'a str,
+}
+
+#[test]
+fn test_fragment_include() {
+    let fragment_include = FragmentInclude { s: "world" };
+    assert_eq!(fragment_include.render().unwrap(), "\nINCLUDED: world\n");
+}


### PR DESCRIPTION
Failing test with include in a fragment

See https://github.com/djc/askama/issues/1063