### PR TITLE
Clippy 1.80

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -19,10 +19,11 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["config", "humansize", "num-traits", "urlencode"]
 config = ["askama_derive/config"]
-humansize = ["askama_derive/humansize", "dep_humansize"]
-num-traits = ["askama_derive/num-traits", "dep_num_traits"]
-serde-json = ["askama_derive/serde-json", "serde", "serde_json"]
-urlencode = ["askama_derive/urlencode", "percent-encoding"]
+humansize = ["askama_derive/humansize", "dep:humansize"]
+num-traits = ["askama_derive/num-traits", "dep:num-traits"]
+serde_json = ["askama_derive/serde-json", "dep:serde", "dep:serde_json"]
+serde-json = ["serde_json"] # Alias for backwards compatibility
+urlencode = ["askama_derive/urlencode", "dep:percent-encoding"]
 with-actix-web = ["askama_derive/with-actix-web"]
 with-axum = ["askama_derive/with-axum"]
 with-rocket = ["askama_derive/with-rocket"]
@@ -35,8 +36,8 @@ mime_guess = []
 [dependencies]
 askama_derive = { version = "0.13", path = "../askama_derive" }
 askama_escape = { version = "0.11", path = "../askama_escape" }
-dep_humansize = { package = "humansize", version = "2", optional = true }
-dep_num_traits = { package = "num-traits", version = "0.2.6", optional = true }
+humansize = { package = "humansize", version = "2", optional = true }
+num-traits = { version = "0.2.6", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -29,10 +29,6 @@ with-axum = ["askama_derive/with-axum"]
 with-rocket = ["askama_derive/with-rocket"]
 with-warp = ["askama_derive/with-warp"]
 
-# deprecated
-mime = []
-mime_guess = []
-
 [dependencies]
 askama_derive = { version = "0.13", path = "../askama_derive" }
 askama_escape = { version = "0.11", path = "../askama_escape" }

--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -16,17 +16,17 @@ pub use self::json::json;
 
 use askama_escape::{Escaper, MarkupDisplay};
 #[cfg(feature = "humansize")]
-use dep_humansize::{ISizeFormatter, ToF64, DECIMAL};
+use humansize::{ISizeFormatter, ToF64, DECIMAL};
 #[cfg(feature = "num-traits")]
-use dep_num_traits::{cast::NumCast, Signed};
-#[cfg(feature = "percent-encoding")]
+use num_traits::{cast::NumCast, Signed};
+#[cfg(feature = "urlencode")]
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 
 use super::Result;
 #[allow(unused_imports)]
 use crate::error::Error::Fmt;
 
-#[cfg(feature = "percent-encoding")]
+#[cfg(feature = "urlencode")]
 // Urlencode char encoding set. Only the characters in the unreserved set don't
 // have any special purpose in any part of a URI and can be safely left
 // unencoded as specified in https://tools.ietf.org/html/rfc3986.html#section-2.3
@@ -36,7 +36,7 @@ const URLENCODE_STRICT_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'-')
     .remove(b'~');
 
-#[cfg(feature = "percent-encoding")]
+#[cfg(feature = "urlencode")]
 // Same as URLENCODE_STRICT_SET, but preserves forward slashes for encoding paths
 const URLENCODE_SET: &AsciiSet = &URLENCODE_STRICT_SET.remove(b'/');
 
@@ -121,7 +121,7 @@ impl fmt::Display for FilesizeFormatFilter {
     }
 }
 
-#[cfg(feature = "percent-encoding")]
+#[cfg(feature = "urlencode")]
 /// Percent-encodes the argument for safe use in URI; does not encode `/`.
 ///
 /// This should be safe for all parts of URI (paths segments, query keys, query
@@ -146,7 +146,7 @@ pub fn urlencode<T: fmt::Display>(s: T) -> Result<impl fmt::Display, Infallible>
     Ok(UrlencodeFilter(s, URLENCODE_SET))
 }
 
-#[cfg(feature = "percent-encoding")]
+#[cfg(feature = "urlencode")]
 /// Percent-encodes the argument for safe use in URI; encodes `/`.
 ///
 /// Use this filter for encoding query keys and values in the rare case that
@@ -166,10 +166,10 @@ pub fn urlencode_strict<T: fmt::Display>(s: T) -> Result<impl fmt::Display, Infa
     Ok(UrlencodeFilter(s, URLENCODE_STRICT_SET))
 }
 
-#[cfg(feature = "percent-encoding")]
+#[cfg(feature = "urlencode")]
 struct UrlencodeFilter<T>(T, &'static AsciiSet);
 
-#[cfg(feature = "percent-encoding")]
+#[cfg(feature = "urlencode")]
 impl<T: fmt::Display> fmt::Display for UrlencodeFilter<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         struct Writer<'a, 'b>(&'a mut fmt::Formatter<'b>, &'static AsciiSet);
@@ -558,7 +558,7 @@ mod tests {
         assert_eq!(filesizeformat(&1024usize).unwrap().to_string(), "1.02 kB");
     }
 
-    #[cfg(feature = "percent-encoding")]
+    #[cfg(feature = "urlencode")]
     #[test]
     fn test_urlencoding() {
         // Unreserved (https://tools.ietf.org/html/rfc3986.html#section-2.3)

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -626,12 +626,12 @@ mod tests {
             [general]
             whitespace = "suppress"
             "#,
-            Some(&"minimize".to_owned()),
+            Some("minimize"),
         )
         .unwrap();
         assert_eq!(config.whitespace, WhitespaceHandling::Minimize);
 
-        let config = Config::new(r#""#, Some(&"minimize".to_owned())).unwrap();
+        let config = Config::new(r#""#, Some("minimize")).unwrap();
         assert_eq!(config.whitespace, WhitespaceHandling::Minimize);
     }
 

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -514,7 +514,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "toml")]
+    #[cfg(feature = "config")]
     #[should_panic]
     #[test]
     fn use_default_at_syntax_name() {
@@ -525,7 +525,7 @@ mod tests {
         let _config = Config::new(raw_config, None).unwrap();
     }
 
-    #[cfg(feature = "toml")]
+    #[cfg(feature = "config")]
     #[should_panic]
     #[test]
     fn duplicated_syntax_name_on_list() {
@@ -537,7 +537,7 @@ mod tests {
         let _config = Config::new(raw_config, None).unwrap();
     }
 
-    #[cfg(feature = "toml")]
+    #[cfg(feature = "config")]
     #[should_panic]
     #[test]
     fn is_not_exist_default_syntax() {
@@ -615,7 +615,7 @@ mod tests {
         assert_eq!(config.whitespace, WhitespaceHandling::Minimize);
     }
 
-    #[cfg(feature = "toml")]
+    #[cfg(feature = "config")]
     #[test]
     fn test_whitespace_in_template() {
         // Checking that template arguments have precedence over general configuration.


### PR DESCRIPTION
Fix guards for non-existent features, and roll in fixes from #1001.