### PR TITLE
Reproduce bug #1075: rendering nested block broken by if-else-endif i…

### DIFF
--- a/testing/templates/fragment-nested-block-bug-if-else-endif.html
+++ b/testing/templates/fragment-nested-block-bug-if-else-endif.html
@@ -1,0 +1,12 @@
+{% extends "fragment-base.html" %}
+
+{% block body %}
+{% if true %}
+true
+{% else %}
+false
+{% endif %}
+{% block nested %}
+<p>I should be here.</p>
+{% endblock %}
+{% endblock %}

--- a/testing/tests/block_fragments.rs
+++ b/testing/tests/block_fragments.rs
@@ -48,6 +48,27 @@ fn test_fragment_nested_block() {
 }
 
 #[derive(Template)]
+#[template(
+    path = "fragment-nested-block-bug-if-else-endif.html",
+    block = "nested"
+)]
+struct FragmentNestedBlockBugIfElseEndif;
+
+/// Reproduce bug https://github.com/djc/askama/issues/1075
+/// When if-else-endif appears outside the rendered block, Buffer::dedent() would error with
+/// "dedent() called while indentation == 0".
+/// The same happens with endif and if, if they are on the same row.
+#[test]
+fn test_fragment_nested_block_bug_if_else_endif() {
+    let nested_block = FragmentNestedBlockBugIfElseEndif {};
+
+    assert_eq!(
+        nested_block.render().unwrap(),
+        "\n<p>I should be here.</p>\n"
+    );
+}
+
+#[derive(Template)]
 #[template(path = "fragment-nested-super.html", block = "body")]
 struct FragmentNestedSuper<'a> {
     name: &'a str,


### PR DESCRIPTION
As requested in https://github.com/djc/askama/issues/1075#issuecomment-2244980638