### PR TITLE
book: fix typo in Template Syntax page

### DIFF
--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -733,6 +733,6 @@ that `entity` was a field of the current type unlike usual. You can go
 around this limitation by binding your field's value into a variable:
 
 ```jinja
-{% let entity = entity; %}
+{% let entity = entity %}
 {{ test_macro!(entity) }}
 ```


### PR DESCRIPTION
The semicolon in `{% let entity = entity; %}` causes the template compilation to fail, so this commit removes it.