### PR TITLE
Suggest disable html escaping in templates in templates section

### DIFF
--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -584,6 +584,11 @@ let t = RenderInPlace { s1: SectionOne { a: "a", b: "b" } };
 assert_eq!(t.render().unwrap(), "Section 1: A=a\nB=b")
 ```
 
+**Note that if your inner template** like `SectionOne` **renders HTML content, you may want to
+disable escaping** when injecting it into an outer template, e.g. `{{ s1|escape("none") }}`;
+otherwise it will render the HTML content literally.
+Askama [escapes HTML variables](#html-escaping) by default.
+
 See the example
 [render in place](https://github.com/djc/askama/blob/main/testing/tests/render_in_place.rs)
 using a vector of templates in a for block.

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -585,8 +585,8 @@ assert_eq!(t.render().unwrap(), "Section 1: A=a\nB=b")
 ```
 
 **Note that if your inner template** like `SectionOne` **renders HTML content, you may want to
-disable escaping** when injecting it into an outer template, e.g. `{{ s1|escape("none") }}`;
-otherwise it will render the HTML content literally.
+disable escaping** when injecting it into an outer template, e.g. `{{ s1|safe }}`.
+Otherwise it will render the HTML content literally, because
 Askama [escapes HTML variables](#html-escaping) by default.
 
 See the example


### PR DESCRIPTION
Suggest in the book that when rendering Html templates in templates, we may want to disable Html escaping.

Fixes #1088 