### PR TITLE
Fix include statements within block fragments

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -822,6 +822,7 @@ impl<'a> Generator<'a> {
         };
         let locals = MapChain::with_parent(&self.locals);
         let mut child = Self::new(self.input, self.contexts, heritage.as_ref(), locals);
+        child.buf_writable.discard = self.buf_writable.discard;
         let mut size_hint = child.handle(handle_ctx, handle_ctx.nodes, buf, AstLevel::Top)?;
         size_hint += child.write_buf_writable(buf)?;
         self.prepare_ws(i.ws);

--- a/testing/templates/fragment-include.html
+++ b/testing/templates/fragment-include.html
@@ -1,0 +1,9 @@
+{% extends "fragment-base.html" %}
+
+{% block body %}
+{% include "included.html" %}
+{% endblock %}
+
+{% block other_body %}
+<p>Don't render me.</p>
+{% endblock %}

--- a/testing/tests/block_fragments.rs
+++ b/testing/tests/block_fragments.rs
@@ -103,3 +103,15 @@ fn test_specific_block() {
     let t = RenderInPlace { s1 };
     assert_eq!(t.render().unwrap(), "\nSection: [abc]\n");
 }
+
+#[derive(Template)]
+#[template(path = "fragment-include.html", block = "body")]
+struct FragmentInclude<'a> {
+    s: &'a str,
+}
+
+#[test]
+fn test_fragment_include() {
+    let fragment_include = FragmentInclude { s: "world" };
+    assert_eq!(fragment_include.render().unwrap(), "\nINCLUDED: world\n");
+}


### PR DESCRIPTION
Fixes #1063. Includes test case courtesy of @OscartGiles in #1066.