### PR TITLE
Add typst in default text escapers

### DIFF
--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -574,7 +574,7 @@ mod tests {
                     "::askama::Html".into()
                 ),
                 (
-                    str_set(&["md", "none", "txt", "yml", ""]),
+                    str_set(&["md", "none", "txt", "yml", "typ", ""]),
                     "::askama::Text".into()
                 ),
                 (str_set(&["j2", "jinja", "jinja2"]), "::askama::Html".into()),

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -305,7 +305,7 @@ static CONFIG_FILE_NAME: &str = "askama.toml";
 static DEFAULT_SYNTAX_NAME: &str = "default";
 static DEFAULT_ESCAPERS: &[(&[&str], &str)] = &[
     (&["html", "htm", "svg", "xml"], "::Html"),
-    (&["md", "none", "txt", "yml", "typ", ""], "::Text"),
+    (&["md", "none", "txt", "typ", "yml", ""], "::Text"),
     (&["j2", "jinja", "jinja2"], "::Html"),
 ];
 
@@ -574,7 +574,7 @@ mod tests {
                     "::askama::Html".into()
                 ),
                 (
-                    str_set(&["md", "none", "txt", "yml", "typ", ""]),
+                    str_set(&["md", "none", "txt", "typ", "yml", ""]),
                     "::askama::Text".into()
                 ),
                 (str_set(&["j2", "jinja", "jinja2"]), "::askama::Html".into()),

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -305,7 +305,7 @@ static CONFIG_FILE_NAME: &str = "askama.toml";
 static DEFAULT_SYNTAX_NAME: &str = "default";
 static DEFAULT_ESCAPERS: &[(&[&str], &str)] = &[
     (&["html", "htm", "svg", "xml"], "::Html"),
-    (&["md", "none", "txt", "yml", ""], "::Text"),
+    (&["md", "none", "txt", "yml", "typ", ""], "::Text"),
     (&["j2", "jinja", "jinja2"], "::Html"),
 ];
 


### PR DESCRIPTION
Added support for [Typst](https://typst.app/) files (.typ extension) by including them in the `DEFAULT-ESCAPERS` under the `::Text` category.