### PR TITLE
Load templates from relative paths

### DIFF
--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -29,6 +29,12 @@ with-axum = ["askama_derive/with-axum"]
 with-rocket = ["askama_derive/with-rocket"]
 with-warp = ["askama_derive/with-warp"]
 
+## Enables the ability to put templates in a directory relative to the source file that uses them.
+## Requires a nightly compiler and adding:
+## RUSTFLAGS='--cfg proc_macro_span --cfg procmacro2_semver_exempt'
+## to your cargo build command.
+relative-paths = ["askama_derive/relative-paths"]
+
 [dependencies]
 askama_derive = { version = "0.13", path = "../askama_derive" }
 askama_escape = { version = "0.11", path = "../askama_escape" }

--- a/askama/tests/relative_paths.rs
+++ b/askama/tests/relative_paths.rs
@@ -1,0 +1,18 @@
+#[cfg(feature = "relative-paths")]
+mod relative_paths {
+    use askama::Template;
+
+    #[derive(Template)]
+    #[template(path = "relative_paths.txt")]
+    struct RelativePathTemplate {
+        name: String,
+    }
+
+    #[test]
+    fn test_relative_paths() {
+        let t = RelativePathTemplate {
+            name: "world".to_string(),
+        };
+        assert_eq!(t.render().unwrap(), "Hello, world!");
+    }
+}

--- a/askama/tests/relative_paths.txt
+++ b/askama/tests/relative_paths.txt
@@ -1,0 +1,1 @@
+Hello, {{ name }}!

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -24,6 +24,12 @@ with-axum = []
 with-rocket = []
 with-warp = []
 
+## Enables the ability to put templates in a directory relative to the source file that uses them.
+## Requires a nightly compiler and adding:
+## RUSTFLAGS='--cfg proc_macro_span --cfg procmacro2_semver_exempt'
+## to your cargo build command.
+relative-paths = []
+
 [dependencies]
 parser = { package = "askama_parser", version = "0.3.1", path = "../askama_parser" }
 mime = "0.3"


### PR DESCRIPTION
Templates can now be placed directly next to the source file that they
are defined in as a default. This relies on an unstable rust compiler
feature, which exposes the source file to proc macros. See
<https://github.com/rust-lang/rust/issues/54725> for more info.

This requires the nightly compiler to run, and enabling the
proc_macro_span and procmacro2_semver_exempt cfg flags. To build / test:

```shell
RUSTFLAGS='--cfg proc_macro_span --cfg procmacro2_semver_exempt' \
  cargo +nightly build
```
Fixes: <https://github.com/djc/askama/issues/877>

---

TODO:
- [ ] docs
- [ ] work out the right name for the feature flag (there's likely a less ambiguous name than `relative-paths` for this)
- [ ] work out if it's possible to compile this without using the nightly compiler. The proc-macro2 crate has shims replacements for the unstable nightly code which can be enabled somehow, but I haven't dug deep enough to understand how / why that is.