### PR TITLE
bump axum-core version to make it compatible with axum 0.8

### DIFF
--- a/askama_axum/Cargo.toml
+++ b/askama_axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_axum"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.65"
 description = "Axum integration for Askama templates"
@@ -15,11 +15,11 @@ readme = "README.md"
 
 [dependencies]
 askama = { version = "0.13", path = "../askama", default-features = false, features = ["with-axum"] }
-axum-core = "0.4"
+axum-core = "0.5"
 http = "1.0"
 
 [dev-dependencies]
-axum = { version = "0.7", default-features = false }
+axum = { version = "0.8", default-features = false }
 http-body-util = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt"] }
 tower = "0.5"


### PR DESCRIPTION
fix #1115

If this PR get merged we would also need to release askama 0.13.0 to crates.io.